### PR TITLE
Kontaktformular auf IONOS SMTP-Backend umstellen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ Thumbs.db
 # Existing
 .playwright-mcp/
 
+# Server (contains SMTP credentials – never commit)
+server/
+
 # Beds24 sync scripts & screenshots
 sync_beds24_photos.mjs
 sync_beds24_photos_result.txt

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -1,7 +1,6 @@
 export default defineAppConfig({
   siteName: 'Pension Volgenandt',
-  formspreeId: 'xPLACEHOLDER', // Replace with real Formspree form ID from https://formspree.io
-  picknickFormspreeId: 'xPICKNICK', // Replace with Formspree form ID for Picknick-Korb inquiries
+  contactFormUrl: 'https://api.pension-volgenandt.de/send-mail.php',
   siteTagline: 'Ruhe finden im Eichsfeld',
   contact: {
     phone: '+49 160 97719112',

--- a/app/components/contact/Form.vue
+++ b/app/components/contact/Form.vue
@@ -16,7 +16,7 @@ async function handleSubmit() {
   errorMessage.value = ''
 
   try {
-    const response = await fetch(`https://formspree.io/f/${appConfig.formspreeId}`, {
+    const response = await fetch(appConfig.contactFormUrl, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -29,15 +29,15 @@ async function handleSubmit() {
       }),
     })
 
-    if (response.ok) {
+    const data = await response.json()
+
+    if (response.ok && data.ok) {
       isSubmitted.value = true
+    } else if (data.errors) {
+      errorMessage.value = data.errors.map((e: { message: string }) => e.message).join(', ')
     } else {
-      const data = await response.json()
-      if (data.errors) {
-        errorMessage.value = data.errors.map((e: { message: string }) => e.message).join(', ')
-      } else {
-        errorMessage.value = 'Leider ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
-      }
+      errorMessage.value =
+        data.error || 'Leider ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
     }
   } catch {
     errorMessage.value =

--- a/app/components/picknick/BookingForm.vue
+++ b/app/components/picknick/BookingForm.vue
@@ -91,7 +91,7 @@ async function handleSubmit() {
   ].filter(Boolean).join('\n')
 
   try {
-    const response = await fetch(`https://formspree.io/f/${appConfig.picknickFormspreeId}`, {
+    const response = await fetch(appConfig.contactFormUrl, {
       method: 'POST',
       headers: {
         Accept: 'application/json',
@@ -100,13 +100,14 @@ async function handleSubmit() {
       body: JSON.stringify({
         name: form.name,
         email: form.email,
-        phone: form.phone || undefined,
         message: messageText,
         _subject: `Picknick-Anfrage: ${selectedPackage.value.name} am ${form.date}`,
       }),
     })
 
-    if (response.ok) {
+    const data = await response.json()
+
+    if (response.ok && data.ok) {
       await router.push({
         path: '/picknick/danke/',
         query: {
@@ -115,11 +116,11 @@ async function handleSubmit() {
           paket: selectedPackage.value.name,
         },
       })
+    } else if (data.errors) {
+      errorMessage.value = data.errors.map((e: { message: string }) => e.message).join(', ')
     } else {
-      const data = await response.json()
-      errorMessage.value = data.errors
-        ? data.errors.map((e: { message: string }) => e.message).join(', ')
-        : 'Leider ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
+      errorMessage.value =
+        data.error || 'Leider ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.'
     }
   } catch {
     errorMessage.value =


### PR DESCRIPTION
## Summary
- Formspree-Platzhalter durch eigenes PHP-Backend auf `api.pension-volgenandt.de` ersetzt
- Kontaktformular und Picknick-Buchungsformular nutzen jetzt authentifiziertes SMTP (smtp.ionos.de:587 + STARTTLS)
- `server/` Verzeichnis in `.gitignore` aufgenommen (enthält SMTP-Zugangsdaten)

## Test plan
- [x] Endpoint getestet via curl – `{"ok":true}` Antwort
- [x] E-Mail kommt bei kontakt@pension-volgenandt.de an
- [ ] Kontaktformular auf der Website testen nach Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)