### PR TITLE
Statistik-Dashboard: GA4, Datensammlung & monatliche Reports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,7 @@ jobs:
         run: pnpm nuxt build --preset github_pages
         env:
           NUXT_APP_BASE_URL: /
+          NUXT_PUBLIC_GA_MEASUREMENT_ID: ${{ secrets.GA_MEASUREMENT_ID }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/monthly-stats.yml
+++ b/.github/workflows/monthly-stats.yml
@@ -1,0 +1,43 @@
+name: Monthly Statistics Collection
+
+on:
+  schedule:
+    # 1st of each month at 07:00 UTC (08:00 CET / 09:00 CEST)
+    - cron: '0 7 1 * *'
+  workflow_dispatch: # Allow manual trigger for testing
+
+jobs:
+  collect:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Collect and send monthly statistics
+        run: node scripts/collect-stats.mjs
+        env:
+          BEDS24_REFRESH_TOKEN: ${{ secrets.BEDS24_REFRESH_TOKEN }}
+          BEDS24_PROPERTY_ID: '261258'
+          GA4_PROPERTY_ID: ${{ secrets.GA4_PROPERTY_ID }}
+          GOOGLE_SERVICE_ACCOUNT_KEY: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY }}
+          GOOGLE_SHEETS_ID: ${{ secrets.GOOGLE_SHEETS_ID }}
+          IONOS_LOG_API_KEY: ${{ secrets.IONOS_LOG_API_KEY }}
+          SMTP_HOST: 'smtp.ionos.de'
+          SMTP_PORT: '587'
+          SMTP_USER: ${{ secrets.SMTP_USER }}
+          SMTP_PASS: ${{ secrets.SMTP_PASS }}
+          REPORT_RECIPIENTS: 'kontakt@pension-volgenandt.de,tina.volgenandt@googlemail.com'
+          LOOKER_STUDIO_URL: ${{ secrets.LOOKER_STUDIO_URL }}

--- a/app/components/CookieSettings.vue
+++ b/app/components/CookieSettings.vue
@@ -8,6 +8,7 @@ const draft = ref<ConsentPreferences>({
   essential: true,
   booking: false,
   media: false,
+  statistics: false,
 })
 
 // Sync draft from cookie when panel opens
@@ -17,6 +18,7 @@ watch(settingsOpen, (open) => {
       essential: true,
       booking: consent.value?.booking ?? false,
       media: consent.value?.media ?? false,
+      statistics: consent.value?.statistics ?? false,
     }
   }
 })
@@ -32,6 +34,7 @@ if (import.meta.client) {
 function saveAndClose() {
   updateCategory('booking', draft.value.booking)
   updateCategory('media', draft.value.media)
+  updateCategory('statistics', draft.value.statistics)
   closeSettings()
 }
 
@@ -65,6 +68,13 @@ const categories: CategoryInfo[] = [
     key: 'media',
     label: 'Medien',
     description: 'Ermöglicht die Einbindung externer Medien wie YouTube-Videos und Google Maps.',
+    disabled: false,
+  },
+  {
+    key: 'statistics',
+    label: 'Statistik',
+    description:
+      'Ermöglicht die anonyme Auswertung der Websitenutzung mit Google Analytics zur Verbesserung unseres Angebots.',
     disabled: false,
   },
 ]

--- a/app/composables/useCookieConsent.ts
+++ b/app/composables/useCookieConsent.ts
@@ -2,6 +2,7 @@ export interface ConsentPreferences {
   essential: boolean // Always true, cannot be toggled
   booking: boolean // Beds24 widget (Phase 5)
   media: boolean // YouTube, Maps (Phase 3+)
+  statistics: boolean // Google Analytics 4
 }
 
 export function useCookieConsent() {
@@ -17,17 +18,17 @@ export function useCookieConsent() {
   const hasConsented = computed(() => consent.value !== null)
 
   function acceptAll() {
-    consent.value = { essential: true, booking: true, media: true }
+    consent.value = { essential: true, booking: true, media: true, statistics: true }
   }
 
   function rejectAll() {
-    consent.value = { essential: true, booking: false, media: false }
+    consent.value = { essential: true, booking: false, media: false, statistics: false }
   }
 
   function updateCategory(category: keyof ConsentPreferences, value: boolean) {
     if (category === 'essential') return
     if (!consent.value) {
-      consent.value = { essential: true, booking: false, media: false }
+      consent.value = { essential: true, booking: false, media: false, statistics: false }
     }
     consent.value = { ...consent.value, [category]: value }
   }

--- a/app/pages/datenschutz.vue
+++ b/app/pages/datenschutz.vue
@@ -341,6 +341,14 @@ useSeoMeta({
           (Einwilligung) und § 25 Abs. 1 TDDDG.
         </p>
 
+        <p class="mt-4 font-semibold">Statistik (Einwilligung erforderlich)</p>
+        <p>
+          Diese Cookies ermöglichen die anonyme Auswertung der Websitenutzung mit Google Analytics
+          zur Verbesserung unseres Angebots. Ohne Ihre Einwilligung werden keine Analysedaten
+          erhoben und es werden keine Daten an Google übermittelt. Rechtsgrundlage: Art. 6 Abs. 1
+          lit. a DSGVO (Einwilligung) und § 25 Abs. 1 TDDDG.
+        </p>
+
         <h3 class="mt-6 mb-3 font-serif text-lg font-semibold text-sage-800">
           Verwaltung Ihrer Cookie-Einstellungen
         </h3>
@@ -354,9 +362,57 @@ useSeoMeta({
         </p>
       </section>
 
-      <!-- 6. Kontaktformular -->
+      <!-- 6. Webanalyse mit Google Analytics 4 -->
       <section>
-        <h2 class="mt-8 mb-4 font-serif text-xl font-semibold text-sage-800">6. Kontaktformular</h2>
+        <h2 class="mt-8 mb-4 font-serif text-xl font-semibold text-sage-800">
+          6. Webanalyse mit Google Analytics 4
+        </h2>
+        <p>
+          Diese Website nutzt Google Analytics 4, einen Webanalysedienst der Google Ireland Limited
+          („Google"), Gordon House, Barrow Street, Dublin 4, Irland. Google Analytics verwendet
+          Cookies, die eine Analyse der Benutzung der Website ermöglichen. Die durch das Cookie
+          erzeugten Informationen über Ihre Benutzung dieser Website werden in der Regel an einen
+          Server von Google in der EU übertragen und dort gespeichert.
+        </p>
+        <p class="mt-2">
+          <strong>IP-Anonymisierung:</strong> Wir nutzen die Funktion zur IP-Anonymisierung. Ihre
+          IP-Adresse wird von Google innerhalb von Mitgliedstaaten der Europäischen Union oder in
+          anderen Vertragsstaaten des Abkommens über den Europäischen Wirtschaftsraum vor der
+          Übermittlung gekürzt.
+        </p>
+        <p class="mt-2">
+          <strong>Erfasste Daten:</strong> Besuchte Seiten, Sitzungsdauer, verwendetes Gerät und
+          Betriebssystem, Herkunft des Besuchs (Suchmaschine, Direktaufruf, Verweis), ungefährer
+          Standort (Land/Stadt), Spracheinstellungen des Browsers.
+        </p>
+        <p class="mt-2">
+          <strong>Zweck:</strong> Analyse und Optimierung unseres Webangebots.
+        </p>
+        <p class="mt-2">
+          <strong>Rechtsgrundlage:</strong> Art. 6 Abs. 1 lit. a DSGVO (Einwilligung) und § 25
+          Abs. 1 TDDDG. Google Analytics wird erst nach Ihrer ausdrücklichen Einwilligung über
+          unsere Cookie-Einstellungen (Kategorie „Statistik") geladen.
+        </p>
+        <p class="mt-2">
+          <strong>Speicherdauer:</strong> 14 Monate. Sie können Ihre Einwilligung jederzeit über die
+          Cookie-Einstellungen in der Fußzeile unserer Website widerrufen.
+        </p>
+        <p class="mt-2">
+          Weitere Informationen zum Datenschutz bei Google finden Sie unter
+          <a
+            href="https://policies.google.com/privacy"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="text-waldhonig-600 underline hover:text-waldhonig-700"
+          >
+            https://policies.google.com/privacy </a
+          >.
+        </p>
+      </section>
+
+      <!-- 7. Kontaktformular -->
+      <section>
+        <h2 class="mt-8 mb-4 font-serif text-xl font-semibold text-sage-800">7. Kontaktformular</h2>
         <p>
           Wenn Sie uns per Kontaktformular Anfragen zukommen lassen, werden Ihre Angaben aus dem
           Anfrageformular inklusive der von Ihnen dort angegebenen Kontaktdaten zwecks Bearbeitung
@@ -380,10 +436,10 @@ useSeoMeta({
         </p>
       </section>
 
-      <!-- 7. Buchungswidget (Beds24) -->
+      <!-- 8. Buchungswidget (Beds24) -->
       <section>
         <h2 class="mt-8 mb-4 font-serif text-xl font-semibold text-sage-800">
-          7. Buchungswidget (Beds24)
+          8. Buchungswidget (Beds24)
         </h2>
         <p>
           Für die Online-Buchung von Zimmern nutzen wir das Buchungssystem des Drittanbieters Beds24
@@ -414,10 +470,10 @@ useSeoMeta({
         </p>
       </section>
 
-      <!-- 8. SSL-/TLS-Verschlüsselung -->
+      <!-- 9. SSL-/TLS-Verschlüsselung -->
       <section>
         <h2 class="mt-8 mb-4 font-serif text-xl font-semibold text-sage-800">
-          8. SSL-/TLS-Verschlüsselung
+          9. SSL-/TLS-Verschlüsselung
         </h2>
         <p>
           Diese Seite nutzt aus Sicherheitsgründen und zum Schutz der Übertragung vertraulicher
@@ -432,10 +488,10 @@ useSeoMeta({
         </p>
       </section>
 
-      <!-- 9. Änderung der Datenschutzerklärung -->
+      <!-- 10. Änderung der Datenschutzerklärung -->
       <section>
         <h2 class="mt-8 mb-4 font-serif text-xl font-semibold text-sage-800">
-          9. Änderung dieser Datenschutzerklärung
+          10. Änderung dieser Datenschutzerklärung
         </h2>
         <p>
           Wir behalten uns vor, diese Datenschutzerklärung anzupassen, damit sie stets den aktuellen

--- a/app/plugins/analytics.client.ts
+++ b/app/plugins/analytics.client.ts
@@ -1,0 +1,43 @@
+export default defineNuxtPlugin(() => {
+  const { isAllowed } = useCookieConsent()
+  const config = useRuntimeConfig()
+  const measurementId = config.public.gaMeasurementId as string
+
+  if (!measurementId) return
+
+  let loaded = false
+
+  function loadGA4() {
+    if (loaded || !isAllowed('statistics')) return
+    loaded = true
+
+    window.dataLayer = window.dataLayer || []
+    window.gtag = function (...args: unknown[]) {
+      window.dataLayer.push(args)
+    }
+    window.gtag('js', new Date())
+    window.gtag('config', measurementId, {
+      anonymize_ip: true,
+      cookie_flags: 'SameSite=Lax;Secure',
+    })
+
+    const script = document.createElement('script')
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+    script.async = true
+    document.head.appendChild(script)
+  }
+
+  watch(() => isAllowed('statistics'), (allowed) => {
+    if (allowed) loadGA4()
+  }, { immediate: true })
+
+  const router = useRouter()
+  router.afterEach((to) => {
+    if (loaded && window.gtag) {
+      window.gtag('event', 'page_view', {
+        page_path: to.fullPath,
+        page_title: document.title,
+      })
+    }
+  })
+})

--- a/app/types/gtag.d.ts
+++ b/app/types/gtag.d.ts
@@ -1,0 +1,8 @@
+declare global {
+  interface Window {
+    dataLayer: unknown[]
+    gtag: (...args: unknown[]) => void
+  }
+}
+
+export {}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -68,6 +68,13 @@ export default defineNuxtConfig({
     },
   },
 
+  // Runtime configuration
+  runtimeConfig: {
+    public: {
+      gaMeasurementId: '', // Set via NUXT_PUBLIC_GA_MEASUREMENT_ID
+    },
+  },
+
   // TypeScript strict mode
   typescript: {
     strict: true,

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "@oxc-parser/binding-win32-x64-msvc": "^0.112.0",
     "@oxc-transform/binding-win32-x64-msvc": "^0.112.0",
     "@tailwindcss/vite": "^4.2.1",
+    "googleapis": "^171.4.0",
+    "nodemailer": "^8.0.3",
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "tailwindcss": "^4.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,6 +94,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.1
         version: 4.2.1(vite@7.3.1(@types/node@25.3.0)(jiti@2.6.1)(lightningcss@1.31.1)(terser@5.46.0)(yaml@2.8.2))
+      googleapis:
+        specifier: ^171.4.0
+        version: 171.4.0
+      nodemailer:
+        specifier: ^8.0.3
+        version: 8.0.3
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -2557,6 +2563,9 @@ packages:
     resolution: {integrity: sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x}
 
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
+
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
@@ -2594,6 +2603,9 @@ packages:
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
     engines: {node: '>=8.0.0'}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -2913,6 +2925,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
     peerDependencies:
@@ -3054,6 +3070,9 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -3400,6 +3419,10 @@ packages:
       picomatch:
         optional: true
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
   fflate@0.7.4:
     resolution: {integrity: sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==}
 
@@ -3470,6 +3493,10 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -3511,6 +3538,14 @@ packages:
     resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
@@ -3602,6 +3637,22 @@ packages:
   globby@16.1.1:
     resolution: {integrity: sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==}
     engines: {node: '>=20'}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
+
+  googleapis-common@8.0.1:
+    resolution: {integrity: sha512-eCzNACUXPb1PW5l0ULTzMHaL/ltPRADoPgjBlT8jWsTbxkCp6siv+qKJ/1ldaybCthGwsYFYallF7u9AkU4L+A==}
+    engines: {node: '>=18.0.0'}
+
+  googleapis@171.4.0:
+    resolution: {integrity: sha512-xybFL2SmmUgIifgsbsRQYRdNrSAYwxWZDmkZTGjUIaRnX5jPqR8el/cEvo6rCqh7iaZx6MfEPS/lrDgZ0bymkg==}
+    engines: {node: '>=18'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3990,6 +4041,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -4011,6 +4065,12 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -4503,6 +4563,11 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
     engines: {node: '>=18'}
@@ -4518,6 +4583,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-forge@1.3.3:
     resolution: {integrity: sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==}
@@ -4537,6 +4606,10 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  nodemailer@8.0.3:
+    resolution: {integrity: sha512-JQNBqvK+bj3NMhUFR3wmCl3SYcOeMotDiwDBvIoCuQdF0PvlIY0BH+FJ2CG7u4cXKPChplE78oowlH/Otsc4ZQ==}
+    engines: {node: '>=6.0.0'}
 
   nopt@5.0.0:
     resolution: {integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==}
@@ -4625,6 +4698,10 @@ packages:
 
   object-deep-merge@2.0.0:
     resolution: {integrity: sha512-3DC3UMpeffLTHiuXSy/UG4NOIYTLlY9u3V82+djSCLYClWobZiS4ivYzpIUWrRY/nfsJ8cWsKyG3QfyLePmhvg==}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -5130,6 +5207,10 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
+    engines: {node: '>=0.6'}
+
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
@@ -5408,6 +5489,22 @@ packages:
   shiki@4.0.2:
     resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
     engines: {node: '>=20'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -5925,6 +6022,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  url-template@2.0.8:
+    resolution: {integrity: sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -6089,6 +6189,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -8847,6 +8951,8 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
+  bignumber.js@9.3.1: {}
+
   bindings@1.5.0:
     dependencies:
       file-uri-to-path: 1.0.0
@@ -8889,6 +8995,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-crc32@1.0.0: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   buffer-from@1.1.2: {}
 
@@ -9236,6 +9344,8 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   db0@0.3.4(better-sqlite3@12.6.2)(sqlite3@5.1.7):
     optionalDependencies:
       better-sqlite3: 12.6.2
@@ -9336,6 +9446,10 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -9754,6 +9868,11 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
   fflate@0.7.4: {}
 
   figures@6.1.0:
@@ -9856,6 +9975,10 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fraction.js@5.3.4: {}
 
   fresh@2.0.0: {}
@@ -9893,6 +10016,22 @@ snapshots:
       strip-ansi: 6.0.1
       wide-align: 1.1.5
     optional: true
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -10004,6 +10143,36 @@ snapshots:
       is-path-inside: 4.0.0
       slash: 5.1.0
       unicorn-magic: 0.4.0
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
+  googleapis-common@8.0.1:
+    dependencies:
+      extend: 3.0.2
+      gaxios: 7.1.4
+      google-auth-library: 10.6.2
+      qs: 6.15.0
+      url-template: 2.0.8
+    transitivePeerDependencies:
+      - supports-color
+
+  googleapis@171.4.0:
+    dependencies:
+      google-auth-library: 10.6.2
+      googleapis-common: 8.0.1
+    transitivePeerDependencies:
+      - supports-color
 
   gopd@1.2.0: {}
 
@@ -10490,6 +10659,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-buffer@3.0.1: {}
 
   json-schema-to-typescript-lite@15.0.0:
@@ -10514,6 +10687,17 @@ snapshots:
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   json5@2.2.3: {}
+
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -11275,6 +11459,8 @@ snapshots:
 
   node-addon-api@7.1.1: {}
 
+  node-domexception@1.0.0: {}
+
   node-emoji@2.2.0:
     dependencies:
       '@sindresorhus/is': 4.6.0
@@ -11289,6 +11475,12 @@ snapshots:
       whatwg-url: 5.0.0
     optionalDependencies:
       encoding: 0.1.13
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-forge@1.3.3: {}
 
@@ -11314,6 +11506,8 @@ snapshots:
   node-mock-http@1.0.4: {}
 
   node-releases@2.0.27: {}
+
+  nodemailer@8.0.3: {}
 
   nopt@5.0.0:
     dependencies:
@@ -11642,6 +11836,8 @@ snapshots:
       tinyexec: 1.0.2
 
   object-deep-merge@2.0.0: {}
+
+  object-inspect@1.13.4: {}
 
   obug@2.1.1: {}
 
@@ -12139,6 +12335,10 @@ snapshots:
 
   punycode@2.3.1: {}
 
+  qs@6.15.0:
+    dependencies:
+      side-channel: 1.1.0
+
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
@@ -12567,6 +12767,34 @@ snapshots:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7:
     optional: true
@@ -13149,6 +13377,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  url-template@2.0.8: {}
+
   util-deprecate@1.0.2: {}
 
   vfile-location@5.0.3:
@@ -13306,6 +13536,8 @@ snapshots:
       typescript: 5.9.3
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@3.3.3: {}
 
   webidl-conversions@3.0.1: {}
 

--- a/scripts/collect-stats.mjs
+++ b/scripts/collect-stats.mjs
@@ -1,0 +1,594 @@
+#!/usr/bin/env node
+/**
+ * Monthly statistics collection for Pension Volgenandt.
+ *
+ * Collects data from:
+ *   1. Beds24 API v2 (bookings, revenue, occupancy)
+ *   2. Google Analytics 4 Data API (website traffic)
+ *   3. IONOS inquiry log (contact form submissions)
+ *
+ * Then:
+ *   - Pushes aggregated data to a Google Sheet
+ *   - Sends a monthly HTML email summary
+ *
+ * Run via: node scripts/collect-stats.mjs
+ * Triggered by: .github/workflows/monthly-stats.yml (1st of each month)
+ */
+
+import { google } from 'googleapis'
+import { createTransport } from 'nodemailer'
+
+// ---------------------------------------------------------------------------
+// Configuration from environment variables
+// ---------------------------------------------------------------------------
+const {
+  BEDS24_REFRESH_TOKEN,
+  BEDS24_PROPERTY_ID = '261258',
+  GA4_PROPERTY_ID,
+  GOOGLE_SERVICE_ACCOUNT_KEY, // base64-encoded JSON
+  GOOGLE_SHEETS_ID,
+  IONOS_LOG_API_KEY,
+  SMTP_HOST = 'smtp.ionos.de',
+  SMTP_PORT = '587',
+  SMTP_USER,
+  SMTP_PASS,
+  REPORT_RECIPIENTS = 'kontakt@pension-volgenandt.de,tina.volgenandt@googlemail.com',
+  LOOKER_STUDIO_URL = '',
+} = process.env
+
+// Calculate previous month date range
+const now = new Date()
+const year = now.getMonth() === 0 ? now.getFullYear() - 1 : now.getFullYear()
+const month = now.getMonth() === 0 ? 12 : now.getMonth() // 1-indexed
+const monthStr = `${year}-${String(month).padStart(2, '0')}`
+const startDate = `${monthStr}-01`
+const daysInMonth = new Date(year, month, 0).getDate()
+const endDate = `${monthStr}-${String(daysInMonth).padStart(2, '0')}`
+
+const MONTH_NAMES_DE = [
+  '', 'Januar', 'Februar', 'März', 'April', 'Mai', 'Juni',
+  'Juli', 'August', 'September', 'Oktober', 'November', 'Dezember',
+]
+const monthLabel = `${MONTH_NAMES_DE[month]} ${year}`
+
+console.log(`Collecting statistics for ${monthLabel} (${startDate} to ${endDate})`)
+
+// Room name mapping
+const ROOM_NAMES = {
+  548066: 'Balkonzimmer',
+  549252: 'Rosengarten',
+  549319: 'Wohlfühl-Appartement',
+  656178: 'Einzelzimmer',
+  656179: "Emil's Kuhwiese",
+  656180: 'Schöne Aussicht',
+}
+const TOTAL_UNITS = Object.keys(ROOM_NAMES).length
+
+// ---------------------------------------------------------------------------
+// 1. Beds24 API
+// ---------------------------------------------------------------------------
+async function collectBeds24Data() {
+  if (!BEDS24_REFRESH_TOKEN) {
+    console.warn('BEDS24_REFRESH_TOKEN not set, skipping Beds24 data')
+    return null
+  }
+
+  // Get access token
+  const tokenRes = await fetch('https://api.beds24.com/v2/authentication/token', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ refreshToken: BEDS24_REFRESH_TOKEN }),
+  })
+  const tokenData = await tokenRes.json()
+  if (!tokenData.token) {
+    console.error('Beds24 token exchange failed:', tokenData)
+    return null
+  }
+  const token = tokenData.token
+
+  // Fetch bookings for the month
+  const params = new URLSearchParams({
+    propertyId: BEDS24_PROPERTY_ID,
+    arrivalFrom: startDate,
+    arrivalTo: endDate,
+    includeInvoice: 'true',
+  })
+  const bookingsRes = await fetch(`https://api.beds24.com/v2/bookings?${params}`, {
+    headers: { token },
+  })
+  const bookings = await bookingsRes.json()
+
+  if (!Array.isArray(bookings)) {
+    console.error('Beds24 bookings response unexpected:', bookings)
+    return null
+  }
+
+  // Calculate metrics
+  let totalBookings = 0
+  let cancellations = 0
+  let totalRevenue = 0
+  let totalNights = 0
+  let totalBookedRoomNights = 0
+  const byRoom = {}
+  const byChannel = {}
+  const guestCountries = {}
+
+  for (const b of bookings) {
+    totalBookings++
+
+    if (b.status === 'cancelled' || b.status === 'canceled') {
+      cancellations++
+      continue
+    }
+
+    // Revenue from invoice
+    if (b.invoice?.total) {
+      totalRevenue += parseFloat(b.invoice.total) || 0
+    }
+
+    // Nights
+    const arrival = new Date(b.arrival || b.firstNight)
+    const departure = new Date(b.departure || b.lastNight)
+    const nights = Math.max(1, Math.round((departure - arrival) / 86400000))
+    totalNights += nights
+    totalBookedRoomNights += nights
+
+    // By room
+    const roomId = String(b.unitId || b.roomId || 'unknown')
+    const roomName = ROOM_NAMES[roomId] || roomId
+    byRoom[roomName] = (byRoom[roomName] || 0) + 1
+
+    // By channel
+    const channel = b.bookingChannel || b.referer || 'Direkt'
+    byChannel[channel] = (byChannel[channel] || 0) + 1
+
+    // Guest country
+    const country = b.guestCountry || b.country || 'Unbekannt'
+    if (country && country !== 'Unbekannt') {
+      guestCountries[country] = (guestCountries[country] || 0) + 1
+    }
+  }
+
+  const confirmedBookings = totalBookings - cancellations
+  const avgStay = confirmedBookings > 0 ? (totalNights / confirmedBookings).toFixed(1) : '0'
+  const totalAvailableRoomNights = TOTAL_UNITS * daysInMonth
+  const occupancyRate = totalAvailableRoomNights > 0
+    ? ((totalBookedRoomNights / totalAvailableRoomNights) * 100).toFixed(1)
+    : '0'
+  const cancellationRate = totalBookings > 0
+    ? ((cancellations / totalBookings) * 100).toFixed(1)
+    : '0'
+
+  // Top room
+  const topRoom = Object.entries(byRoom).sort((a, b) => b[1] - a[1])[0]
+  // Top channel
+  const topChannel = Object.entries(byChannel).sort((a, b) => b[1] - a[1])[0]
+  // Top country
+  const topCountry = Object.entries(guestCountries).sort((a, b) => b[1] - a[1])[0]
+
+  return {
+    totalBookings,
+    confirmedBookings,
+    cancellations,
+    cancellationRate,
+    totalRevenue: totalRevenue.toFixed(2),
+    avgStay,
+    occupancyRate,
+    topRoom: topRoom ? topRoom[0] : '–',
+    topChannel: topChannel ? topChannel[0] : '–',
+    topCountry: topCountry ? topCountry[0] : '–',
+    byRoom,
+    byChannel,
+    guestCountries,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Google Analytics 4 Data API
+// ---------------------------------------------------------------------------
+async function collectGA4Data() {
+  if (!GA4_PROPERTY_ID || !GOOGLE_SERVICE_ACCOUNT_KEY) {
+    console.warn('GA4 credentials not set, skipping GA4 data')
+    return null
+  }
+
+  const keyJson = JSON.parse(Buffer.from(GOOGLE_SERVICE_ACCOUNT_KEY, 'base64').toString())
+  const auth = new google.auth.GoogleAuth({
+    credentials: keyJson,
+    scopes: ['https://www.googleapis.com/auth/analytics.readonly'],
+  })
+
+  const analyticsData = google.analyticsdata({ version: 'v1beta', auth })
+
+  // Run report
+  const res = await analyticsData.properties.runReport({
+    property: `properties/${GA4_PROPERTY_ID}`,
+    requestBody: {
+      dateRanges: [{ startDate, endDate }],
+      metrics: [
+        { name: 'sessions' },
+        { name: 'totalUsers' },
+        { name: 'screenPageViews' },
+        { name: 'bounceRate' },
+        { name: 'averageSessionDuration' },
+      ],
+      dimensions: [],
+    },
+  })
+
+  const row = res.data.rows?.[0]
+  const sessions = row?.metricValues?.[0]?.value || '0'
+  const users = row?.metricValues?.[1]?.value || '0'
+  const pageviews = row?.metricValues?.[2]?.value || '0'
+  const bounceRate = parseFloat(row?.metricValues?.[3]?.value || '0').toFixed(1)
+  const avgSessionDuration = parseFloat(row?.metricValues?.[4]?.value || '0').toFixed(0)
+
+  // Top pages
+  const pagesRes = await analyticsData.properties.runReport({
+    property: `properties/${GA4_PROPERTY_ID}`,
+    requestBody: {
+      dateRanges: [{ startDate, endDate }],
+      metrics: [{ name: 'screenPageViews' }],
+      dimensions: [{ name: 'pagePath' }],
+      orderBys: [{ metric: { metricName: 'screenPageViews' }, desc: true }],
+      limit: 10,
+    },
+  })
+
+  const topPages = (pagesRes.data.rows || []).map((r) => ({
+    page: r.dimensionValues[0].value,
+    views: r.metricValues[0].value,
+  }))
+
+  // Traffic sources
+  const sourcesRes = await analyticsData.properties.runReport({
+    property: `properties/${GA4_PROPERTY_ID}`,
+    requestBody: {
+      dateRanges: [{ startDate, endDate }],
+      metrics: [{ name: 'sessions' }],
+      dimensions: [{ name: 'sessionDefaultChannelGroup' }],
+      orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+      limit: 10,
+    },
+  })
+
+  const sources = (sourcesRes.data.rows || []).map((r) => ({
+    source: r.dimensionValues[0].value,
+    sessions: r.metricValues[0].value,
+  }))
+
+  // Device categories
+  const devicesRes = await analyticsData.properties.runReport({
+    property: `properties/${GA4_PROPERTY_ID}`,
+    requestBody: {
+      dateRanges: [{ startDate, endDate }],
+      metrics: [{ name: 'sessions' }],
+      dimensions: [{ name: 'deviceCategory' }],
+    },
+  })
+
+  const devices = (devicesRes.data.rows || []).map((r) => ({
+    device: r.dimensionValues[0].value,
+    sessions: r.metricValues[0].value,
+  }))
+
+  // Countries
+  const countriesRes = await analyticsData.properties.runReport({
+    property: `properties/${GA4_PROPERTY_ID}`,
+    requestBody: {
+      dateRanges: [{ startDate, endDate }],
+      metrics: [{ name: 'sessions' }],
+      dimensions: [{ name: 'country' }],
+      orderBys: [{ metric: { metricName: 'sessions' }, desc: true }],
+      limit: 10,
+    },
+  })
+
+  const countries = (countriesRes.data.rows || []).map((r) => ({
+    country: r.dimensionValues[0].value,
+    sessions: r.metricValues[0].value,
+  }))
+
+  const topPage = topPages[0]?.page || '–'
+  const topSource = sources[0]?.source || '–'
+
+  return {
+    sessions,
+    users,
+    pageviews,
+    bounceRate,
+    avgSessionDuration,
+    topPages,
+    sources,
+    devices,
+    countries,
+    topPage,
+    topSource,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Email Inquiry Log
+// ---------------------------------------------------------------------------
+async function collectInquiryData() {
+  if (!IONOS_LOG_API_KEY) {
+    console.warn('IONOS_LOG_API_KEY not set, skipping inquiry data')
+    return null
+  }
+
+  const url = `https://api.pension-volgenandt.de/get-inquiry-log.php?key=${IONOS_LOG_API_KEY}&month=${monthStr}`
+  const res = await fetch(url)
+  const data = await res.json()
+
+  if (!data.entries) return null
+
+  const entries = data.entries
+  const total = entries.length
+  const byType = {}
+
+  for (const e of entries) {
+    const type = e.type || 'Kontaktanfrage'
+    byType[type] = (byType[type] || 0) + 1
+  }
+
+  return { total, byType }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Push to Google Sheet
+// ---------------------------------------------------------------------------
+async function pushToGoogleSheet(beds24, ga4, inquiries) {
+  if (!GOOGLE_SERVICE_ACCOUNT_KEY || !GOOGLE_SHEETS_ID) {
+    console.warn('Google Sheets credentials not set, skipping sheet update')
+    return
+  }
+
+  const keyJson = JSON.parse(Buffer.from(GOOGLE_SERVICE_ACCOUNT_KEY, 'base64').toString())
+  const auth = new google.auth.GoogleAuth({
+    credentials: keyJson,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  })
+
+  const sheets = google.sheets({ version: 'v4', auth })
+
+  const row = [
+    monthLabel,
+    beds24?.confirmedBookings ?? '–',
+    beds24?.cancellations ?? '–',
+    beds24?.totalRevenue ?? '–',
+    beds24?.occupancyRate ? `${beds24.occupancyRate}%` : '–',
+    beds24?.avgStay ?? '–',
+    beds24?.cancellationRate ? `${beds24.cancellationRate}%` : '–',
+    beds24?.topRoom ?? '–',
+    beds24?.topChannel ?? '–',
+    beds24?.topCountry ?? '–',
+    ga4?.sessions ?? '–',
+    ga4?.users ?? '–',
+    ga4?.pageviews ?? '–',
+    ga4?.bounceRate ? `${ga4.bounceRate}%` : '–',
+    ga4?.topPage ?? '–',
+    ga4?.topSource ?? '–',
+    inquiries?.total ?? '–',
+  ]
+
+  // Check if header row exists
+  const existing = await sheets.spreadsheets.values.get({
+    spreadsheetId: GOOGLE_SHEETS_ID,
+    range: 'Monatsdaten!A1:Q1',
+  })
+
+  if (!existing.data.values || existing.data.values.length === 0) {
+    // Write header row
+    await sheets.spreadsheets.values.update({
+      spreadsheetId: GOOGLE_SHEETS_ID,
+      range: 'Monatsdaten!A1',
+      valueInputOption: 'RAW',
+      requestBody: {
+        values: [[
+          'Monat', 'Buchungen', 'Stornierungen', 'Umsatz (€)', 'Auslastung',
+          'Ø Aufenthalt (Nächte)', 'Storno-Rate', 'Top Zimmer', 'Top Kanal',
+          'Top Land (Gäste)', 'Sessions', 'Nutzer', 'Seitenaufrufe',
+          'Absprungrate', 'Top Seite', 'Top Quelle', 'Anfragen',
+        ]],
+      },
+    })
+  }
+
+  // Append data row
+  await sheets.spreadsheets.values.append({
+    spreadsheetId: GOOGLE_SHEETS_ID,
+    range: 'Monatsdaten!A:Q',
+    valueInputOption: 'RAW',
+    requestBody: { values: [row] },
+  })
+
+  console.log('Google Sheet updated successfully')
+}
+
+// ---------------------------------------------------------------------------
+// 5. HTML Email
+// ---------------------------------------------------------------------------
+function buildEmailHtml(beds24, ga4, inquiries) {
+  const kpi = (label, value) => `
+    <td style="padding:12px 16px;text-align:center;background:#f8f7f4;border-radius:8px;">
+      <div style="font-size:24px;font-weight:bold;color:#4a6741;">${value}</div>
+      <div style="font-size:12px;color:#6b7c68;margin-top:4px;">${label}</div>
+    </td>`
+
+  const tableRow = (label, value) => `
+    <tr>
+      <td style="padding:6px 12px;color:#4a4a4a;">${label}</td>
+      <td style="padding:6px 12px;text-align:right;font-weight:600;color:#2d3b28;">${value}</td>
+    </tr>`
+
+  const section = (title, content) => `
+    <div style="margin-top:24px;">
+      <h2 style="font-size:18px;color:#2d3b28;border-bottom:2px solid #c9a84c;padding-bottom:8px;margin-bottom:16px;">${title}</h2>
+      ${content}
+    </div>`
+
+  // KPIs
+  let kpis = '<table style="width:100%;border-spacing:8px;"><tr>'
+  kpis += kpi('Buchungen', beds24?.confirmedBookings ?? '–')
+  kpis += kpi('Umsatz', beds24?.totalRevenue ? `${beds24.totalRevenue} €` : '–')
+  kpis += kpi('Auslastung', beds24?.occupancyRate ? `${beds24.occupancyRate}%` : '–')
+  kpis += kpi('Besucher', ga4?.users ?? '–')
+  kpis += kpi('Anfragen', inquiries?.total ?? '–')
+  kpis += '</tr></table>'
+
+  // Bookings section
+  let bookingsHtml = ''
+  if (beds24) {
+    let rows = ''
+    rows += tableRow('Bestätigte Buchungen', beds24.confirmedBookings)
+    rows += tableRow('Stornierungen', `${beds24.cancellations} (${beds24.cancellationRate}%)`)
+    rows += tableRow('Gesamtumsatz', `${beds24.totalRevenue} €`)
+    rows += tableRow('Ø Aufenthalt', `${beds24.avgStay} Nächte`)
+    rows += tableRow('Auslastung', `${beds24.occupancyRate}%`)
+    rows += tableRow('Beliebtestes Zimmer', beds24.topRoom)
+    rows += tableRow('Top Buchungskanal', beds24.topChannel)
+    rows += tableRow('Top Herkunftsland', beds24.topCountry)
+
+    if (Object.keys(beds24.byRoom).length > 0) {
+      rows += '<tr><td colspan="2" style="padding-top:12px;font-weight:600;color:#4a6741;">Nach Zimmer:</td></tr>'
+      for (const [room, count] of Object.entries(beds24.byRoom).sort((a, b) => b[1] - a[1])) {
+        rows += tableRow(`  ${room}`, count)
+      }
+    }
+
+    bookingsHtml = section('Buchungen & Umsatz', `<table style="width:100%;">${rows}</table>`)
+  }
+
+  // Website section
+  let websiteHtml = ''
+  if (ga4) {
+    let rows = ''
+    rows += tableRow('Sessions', ga4.sessions)
+    rows += tableRow('Nutzer', ga4.users)
+    rows += tableRow('Seitenaufrufe', ga4.pageviews)
+    rows += tableRow('Absprungrate', `${ga4.bounceRate}%`)
+    rows += tableRow('Ø Sitzungsdauer', `${ga4.avgSessionDuration}s`)
+
+    if (ga4.topPages.length > 0) {
+      rows += '<tr><td colspan="2" style="padding-top:12px;font-weight:600;color:#4a6741;">Top Seiten:</td></tr>'
+      for (const p of ga4.topPages.slice(0, 5)) {
+        rows += tableRow(`  ${p.page}`, `${p.views} Aufrufe`)
+      }
+    }
+
+    if (ga4.sources.length > 0) {
+      rows += '<tr><td colspan="2" style="padding-top:12px;font-weight:600;color:#4a6741;">Traffic-Quellen:</td></tr>'
+      for (const s of ga4.sources.slice(0, 5)) {
+        rows += tableRow(`  ${s.source}`, `${s.sessions} Sessions`)
+      }
+    }
+
+    websiteHtml = section('Website-Traffic', `<table style="width:100%;">${rows}</table>`)
+  }
+
+  // Inquiries section
+  let inquiriesHtml = ''
+  if (inquiries && inquiries.total > 0) {
+    let rows = tableRow('Gesamt', inquiries.total)
+    for (const [type, count] of Object.entries(inquiries.byType)) {
+      rows += tableRow(`  ${type}`, count)
+    }
+    inquiriesHtml = section('Kontaktanfragen', `<table style="width:100%;">${rows}</table>`)
+  }
+
+  const dashboardLink = LOOKER_STUDIO_URL
+    ? `<p style="text-align:center;margin-top:24px;">
+        <a href="${LOOKER_STUDIO_URL}" style="display:inline-block;padding:12px 24px;background:#c9a84c;color:#fff;border-radius:8px;text-decoration:none;font-weight:600;">
+          Dashboard öffnen
+        </a>
+      </p>`
+    : ''
+
+  return `
+<!DOCTYPE html>
+<html lang="de">
+<head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:600px;margin:0 auto;padding:24px;color:#333;">
+  <div style="text-align:center;padding:24px 0;border-bottom:3px solid #c9a84c;">
+    <h1 style="font-size:24px;color:#2d3b28;margin:0;">Pension Volgenandt</h1>
+    <p style="color:#6b7c68;margin:8px 0 0;">Monatsbericht ${monthLabel}</p>
+  </div>
+
+  ${kpis}
+  ${bookingsHtml}
+  ${websiteHtml}
+  ${inquiriesHtml}
+  ${dashboardLink}
+
+  <p style="text-align:center;color:#999;font-size:12px;margin-top:32px;border-top:1px solid #eee;padding-top:16px;">
+    Automatisch erstellt am ${new Date().toLocaleDateString('de-DE')}
+  </p>
+</body>
+</html>`
+}
+
+// ---------------------------------------------------------------------------
+// 6. Send Email
+// ---------------------------------------------------------------------------
+async function sendEmail(html) {
+  if (!SMTP_USER || !SMTP_PASS) {
+    console.warn('SMTP credentials not set, skipping email')
+    console.log('Email HTML preview saved (would have been sent)')
+    return
+  }
+
+  const transporter = createTransport({
+    host: SMTP_HOST,
+    port: parseInt(SMTP_PORT),
+    secure: false,
+    auth: { user: SMTP_USER, pass: SMTP_PASS },
+    tls: { rejectUnauthorized: false },
+  })
+
+  const recipients = REPORT_RECIPIENTS.split(',').map((e) => e.trim())
+
+  await transporter.sendMail({
+    from: `"Pension Volgenandt" <${SMTP_USER}>`,
+    to: recipients.join(', '),
+    subject: `Monatsbericht ${monthLabel} – Pension Volgenandt`,
+    html,
+  })
+
+  console.log(`Email sent to: ${recipients.join(', ')}`)
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  console.log('Starting monthly statistics collection...\n')
+
+  const [beds24, ga4, inquiries] = await Promise.all([
+    collectBeds24Data().catch((e) => { console.error('Beds24 error:', e.message); return null }),
+    collectGA4Data().catch((e) => { console.error('GA4 error:', e.message); return null }),
+    collectInquiryData().catch((e) => { console.error('Inquiry error:', e.message); return null }),
+  ])
+
+  console.log('\n--- Results ---')
+  if (beds24) console.log(`Beds24: ${beds24.confirmedBookings} bookings, ${beds24.totalRevenue}€ revenue, ${beds24.occupancyRate}% occupancy`)
+  if (ga4) console.log(`GA4: ${ga4.sessions} sessions, ${ga4.users} users, ${ga4.pageviews} pageviews`)
+  if (inquiries) console.log(`Inquiries: ${inquiries.total} total`)
+
+  // Push to Google Sheet
+  await pushToGoogleSheet(beds24, ga4, inquiries).catch((e) => {
+    console.error('Google Sheets error:', e.message)
+  })
+
+  // Build and send email
+  const html = buildEmailHtml(beds24, ga4, inquiries)
+  await sendEmail(html).catch((e) => {
+    console.error('Email error:', e.message)
+  })
+
+  console.log('\nDone!')
+}
+
+main().catch((e) => {
+  console.error('Fatal error:', e)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
- **GA4-Tracking** mit Cookie-Consent-Gating (neue Statistik-Kategorie im Cookie-Banner)
- **Datenschutz-Seite** um Google Analytics 4 Abschnitt erweitert (DSGVO-konform)
- **Monatliches Datensammlungs-Script** (`collect-stats.mjs`): sammelt Beds24-Buchungen, GA4-Traffic-Daten und Kontaktanfragen
- **GitHub Actions Workflow** (`monthly-stats.yml`): läuft automatisch am 1. jeden Monats
- **Google Sheets** als Datenhub für Looker Studio Dashboard
- **Kontaktformular-Logging** (CSV) und API-Endpunkt auf IONOS deployed

## Noch zu erledigen (manuell)
- [ ] GA4-Property erstellen und Measurement ID als GitHub Secret setzen
- [ ] Beds24 API Token generieren
- [ ] Google Cloud Projekt + Service Account einrichten
- [ ] Google Sheet erstellen und mit Service Account teilen
- [ ] Alle GitHub Secrets konfigurieren
- [ ] Looker Studio Dashboard aufbauen

## Test plan
- [ ] Cookie-Banner zeigt Statistik-Kategorie
- [ ] GA4 lädt nur nach Consent
- [ ] Datenschutz-Seite hat korrekten GA4-Abschnitt
- [ ] `workflow_dispatch` manuell testen nach Secret-Setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)