### PR TITLE
feat: SEO-Maßnahmen aus Wettbewerbsanalyse

### DIFF
--- a/app/components/home/HeroLgsBanner.vue
+++ b/app/components/home/HeroLgsBanner.vue
@@ -2,42 +2,8 @@
 import { t } from '~/utils/translations'
 
 const { locale } = useLocale()
-
-const EVENT_START = new Date('2026-04-23T00:00:00+02:00')
-const EVENT_END = new Date('2026-10-11T23:59:59+02:00')
-
-const now = ref(new Date())
-const mounted = ref(false)
-
-// Client-side only — avoids SSG hydration mismatch
-onMounted(() => {
-  mounted.value = true
-  now.value = new Date()
-
-  const interval = setInterval(() => {
-    now.value = new Date()
-  }, 60_000)
-
-  onUnmounted(() => clearInterval(interval))
-})
-
-const daysUntil = computed(() => {
-  const diff = EVENT_START.getTime() - now.value.getTime()
-  return Math.ceil(diff / (1000 * 60 * 60 * 24))
-})
-
-const isLive = computed(() => now.value >= EVENT_START && now.value <= EVENT_END)
-const isExpired = computed(() => now.value > EVENT_END)
-const showBanner = computed(() => mounted.value && !isExpired.value)
-
-const countdownText = computed(() => {
-  if (isLive.value) return t('lgs.liveNow', locale.value)
-  if (daysUntil.value === 1) return t('lgs.countdownOne', locale.value)
-  return t('lgs.countdown', locale.value).replace('{days}', String(daysUntil.value))
-})
-
-const linkTarget = computed(() =>
-  locale.value === 'en' ? '/en/news/landesgartenschau-2026/' : '/aktuelles/landesgartenschau-2026/',
+const { daysUntil, isLive, showBanner, countdownText, linkTarget } = useLgsCountdown(
+  computed(() => locale.value),
 )
 </script>
 

--- a/app/components/home/HeroLgsBanner.vue
+++ b/app/components/home/HeroLgsBanner.vue
@@ -46,7 +46,7 @@ const linkTarget = computed(() =>
   <NuxtLink
     v-if="showBanner"
     :to="linkTarget"
-    class="hero-animate group absolute right-6 bottom-24 z-[5] hidden flex-col items-center rounded-xl border border-white/20 bg-white/15 px-5 py-4 text-center backdrop-blur-md transition-transform hover:scale-[1.03] md:flex lg:right-12"
+    class="hero-animate group absolute right-6 bottom-24 z-20 hidden flex-col items-center rounded-xl border border-white/20 bg-white/15 px-5 py-4 text-center backdrop-blur-md transition-transform hover:scale-[1.03] md:flex lg:right-12"
     style="animation-delay: 2000ms"
   >
     <span class="text-xs font-semibold tracking-wide text-white/80 uppercase">

--- a/app/components/home/HeroLgsBanner.vue
+++ b/app/components/home/HeroLgsBanner.vue
@@ -1,0 +1,68 @@
+<script setup lang="ts">
+import { t } from '~/utils/translations'
+
+const { locale } = useLocale()
+
+const EVENT_START = new Date('2026-04-23T00:00:00+02:00')
+const EVENT_END = new Date('2026-10-11T23:59:59+02:00')
+
+const now = ref(new Date())
+const mounted = ref(false)
+
+// Client-side only — avoids SSG hydration mismatch
+onMounted(() => {
+  mounted.value = true
+  now.value = new Date()
+
+  const interval = setInterval(() => {
+    now.value = new Date()
+  }, 60_000)
+
+  onUnmounted(() => clearInterval(interval))
+})
+
+const daysUntil = computed(() => {
+  const diff = EVENT_START.getTime() - now.value.getTime()
+  return Math.ceil(diff / (1000 * 60 * 60 * 24))
+})
+
+const isLive = computed(() => now.value >= EVENT_START && now.value <= EVENT_END)
+const isExpired = computed(() => now.value > EVENT_END)
+const showBanner = computed(() => mounted.value && !isExpired.value)
+
+const countdownText = computed(() => {
+  if (isLive.value) return t('lgs.liveNow', locale.value)
+  if (daysUntil.value === 1) return t('lgs.countdownOne', locale.value)
+  return t('lgs.countdown', locale.value).replace('{days}', String(daysUntil.value))
+})
+
+const linkTarget = computed(() =>
+  locale.value === 'en' ? '/en/news/landesgartenschau-2026/' : '/aktuelles/landesgartenschau-2026/',
+)
+</script>
+
+<template>
+  <!-- Desktop overlay (inside hero) -->
+  <NuxtLink
+    v-if="showBanner"
+    :to="linkTarget"
+    class="hero-animate group absolute right-6 bottom-24 z-[5] hidden flex-col items-center rounded-xl border border-white/20 bg-white/15 px-5 py-4 text-center backdrop-blur-md transition-transform hover:scale-[1.03] md:flex lg:right-12"
+    style="animation-delay: 2000ms"
+  >
+    <span class="text-xs font-semibold tracking-wide text-white/80 uppercase">
+      {{ t('lgs.bannerTitle', locale) }}
+    </span>
+    <span v-if="!isLive" class="mt-1 font-serif text-3xl font-bold text-waldhonig-400">
+      {{ daysUntil }}
+    </span>
+    <span class="mt-1 text-sm font-medium text-white">
+      {{ countdownText }}
+    </span>
+    <span
+      class="mt-2 inline-flex items-center gap-1 text-xs font-semibold text-waldhonig-400 transition-colors group-hover:text-waldhonig-300"
+    >
+      {{ t('lgs.linkText', locale) }}
+      <Icon name="ph:arrow-right" class="size-3.5" />
+    </span>
+  </NuxtLink>
+</template>

--- a/app/components/home/HeroLgsBannerMobile.vue
+++ b/app/components/home/HeroLgsBannerMobile.vue
@@ -2,41 +2,8 @@
 import { t } from '~/utils/translations'
 
 const { locale } = useLocale()
-
-const EVENT_START = new Date('2026-04-23T00:00:00+02:00')
-const EVENT_END = new Date('2026-10-11T23:59:59+02:00')
-
-const now = ref(new Date())
-const mounted = ref(false)
-
-onMounted(() => {
-  mounted.value = true
-  now.value = new Date()
-
-  const interval = setInterval(() => {
-    now.value = new Date()
-  }, 60_000)
-
-  onUnmounted(() => clearInterval(interval))
-})
-
-const daysUntil = computed(() => {
-  const diff = EVENT_START.getTime() - now.value.getTime()
-  return Math.ceil(diff / (1000 * 60 * 60 * 24))
-})
-
-const isLive = computed(() => now.value >= EVENT_START && now.value <= EVENT_END)
-const isExpired = computed(() => now.value > EVENT_END)
-const showBanner = computed(() => mounted.value && !isExpired.value)
-
-const countdownText = computed(() => {
-  if (isLive.value) return t('lgs.liveNow', locale.value)
-  if (daysUntil.value === 1) return t('lgs.countdownOne', locale.value)
-  return t('lgs.countdown', locale.value).replace('{days}', String(daysUntil.value))
-})
-
-const linkTarget = computed(() =>
-  locale.value === 'en' ? '/en/news/landesgartenschau-2026/' : '/aktuelles/landesgartenschau-2026/',
+const { daysUntil, isLive, showBanner, countdownText, linkTarget } = useLgsCountdown(
+  computed(() => locale.value),
 )
 </script>
 

--- a/app/components/home/HeroLgsBannerMobile.vue
+++ b/app/components/home/HeroLgsBannerMobile.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { t } from '~/utils/translations'
+
+const { locale } = useLocale()
+
+const EVENT_START = new Date('2026-04-23T00:00:00+02:00')
+const EVENT_END = new Date('2026-10-11T23:59:59+02:00')
+
+const now = ref(new Date())
+const mounted = ref(false)
+
+onMounted(() => {
+  mounted.value = true
+  now.value = new Date()
+
+  const interval = setInterval(() => {
+    now.value = new Date()
+  }, 60_000)
+
+  onUnmounted(() => clearInterval(interval))
+})
+
+const daysUntil = computed(() => {
+  const diff = EVENT_START.getTime() - now.value.getTime()
+  return Math.ceil(diff / (1000 * 60 * 60 * 24))
+})
+
+const isLive = computed(() => now.value >= EVENT_START && now.value <= EVENT_END)
+const isExpired = computed(() => now.value > EVENT_END)
+const showBanner = computed(() => mounted.value && !isExpired.value)
+
+const countdownText = computed(() => {
+  if (isLive.value) return t('lgs.liveNow', locale.value)
+  if (daysUntil.value === 1) return t('lgs.countdownOne', locale.value)
+  return t('lgs.countdown', locale.value).replace('{days}', String(daysUntil.value))
+})
+
+const linkTarget = computed(() =>
+  locale.value === 'en' ? '/en/news/landesgartenschau-2026/' : '/aktuelles/landesgartenschau-2026/',
+)
+</script>
+
+<template>
+  <NuxtLink
+    v-if="showBanner"
+    :to="linkTarget"
+    class="group flex items-center gap-3 border-b border-waldhonig-200 bg-waldhonig-50 px-4 py-2.5 md:hidden"
+  >
+    <span
+      v-if="!isLive"
+      class="flex size-9 shrink-0 items-center justify-center rounded-full bg-waldhonig-500 font-serif text-base font-bold text-white"
+    >
+      {{ daysUntil }}
+    </span>
+    <span
+      v-else
+      class="flex size-9 shrink-0 items-center justify-center rounded-full bg-waldhonig-500"
+    >
+      <Icon name="ph:flower-tulip" class="size-4.5 text-white" />
+    </span>
+    <div class="min-w-0 flex-1">
+      <p class="truncate text-sm font-semibold text-sage-900">
+        {{ t('lgs.bannerTitle', locale) }}
+        <span class="text-sage-500">&middot;</span>
+        <span class="font-normal text-sage-600">{{ countdownText }}</span>
+      </p>
+    </div>
+    <Icon
+      name="ph:caret-right-bold"
+      class="size-4 shrink-0 text-waldhonig-500 transition-transform group-hover:translate-x-0.5"
+    />
+  </NuxtLink>
+</template>

--- a/app/components/home/HeroVideo.vue
+++ b/app/components/home/HeroVideo.vue
@@ -127,6 +127,8 @@ if (import.meta.client) {
 </template>
 
 <style scoped>
+/* Z-index stack: poster=1, video=2, gradient=3, text=10, LGS banner=20 */
+
 /* Poster layers — always visible under the video */
 .hero-poster {
   z-index: 1;

--- a/app/components/home/HeroVideo.vue
+++ b/app/components/home/HeroVideo.vue
@@ -113,6 +113,9 @@ if (import.meta.client) {
       </div>
     </div>
 
+    <!-- LGS countdown banner (desktop only — mobile variant in page) -->
+    <HomeHeroLgsBanner />
+
     <!-- Scroll indicator -->
     <UiScrollIndicator
       :visible="scrollIndicatorVisible"

--- a/app/composables/useLgsCountdown.ts
+++ b/app/composables/useLgsCountdown.ts
@@ -1,0 +1,44 @@
+import { t } from '~/utils/translations'
+import type { Locale } from '~/composables/useLocale'
+
+const EVENT_START = new Date('2026-04-23T00:00:00+02:00')
+const EVENT_END = new Date('2026-10-11T23:59:59+02:00')
+
+export function useLgsCountdown(locale: Ref<Locale>) {
+  const now = ref(new Date())
+  const mounted = ref(false)
+
+  onMounted(() => {
+    mounted.value = true
+    now.value = new Date()
+
+    const interval = setInterval(() => {
+      now.value = new Date()
+    }, 60_000)
+
+    onUnmounted(() => clearInterval(interval))
+  })
+
+  const daysUntil = computed(() => {
+    const diff = EVENT_START.getTime() - now.value.getTime()
+    return Math.ceil(diff / (1000 * 60 * 60 * 24))
+  })
+
+  const isLive = computed(() => now.value >= EVENT_START && now.value <= EVENT_END)
+  const isExpired = computed(() => now.value > EVENT_END)
+  const showBanner = computed(() => mounted.value && !isExpired.value)
+
+  const countdownText = computed(() => {
+    if (isLive.value) return t('lgs.liveNow', locale.value)
+    if (daysUntil.value === 1) return t('lgs.countdownOne', locale.value)
+    return t('lgs.countdown', locale.value).replace('{days}', String(daysUntil.value))
+  })
+
+  const linkTarget = computed(() =>
+    locale.value === 'en'
+      ? '/en/news/landesgartenschau-2026/'
+      : '/aktuelles/landesgartenschau-2026/',
+  )
+
+  return { daysUntil, isLive, isExpired, showBanner, countdownText, linkTarget }
+}

--- a/app/composables/useLocale.ts
+++ b/app/composables/useLocale.ts
@@ -13,6 +13,8 @@ const deToEn: Record<string, string> = {
   '/datenschutz': '/privacy',
   '/agb': '/terms',
   '/picknick': '/picnic',
+  '/ferienwohnungen': '/holiday-apartments',
+  '/monteurzimmer': '/worker-rooms',
 }
 
 const enToDe: Record<string, string> = Object.fromEntries(

--- a/app/i18n/locales/de.json
+++ b/app/i18n/locales/de.json
@@ -290,5 +290,43 @@
     "foehn": "Föhn",
     "tisch": "Kleiner Tisch",
     "heizung": "Heizung"
+  },
+  "lgs": {
+    "bannerTitle": "Landesgartenschau 2026",
+    "countdown": "Noch {days} Tage",
+    "countdownOne": "Noch 1 Tag",
+    "liveNow": "Jetzt erleben!",
+    "linkText": "Unterkunft sichern",
+    "pageTitle": "Unterkunft zur Landesgartenschau 2026",
+    "pageSubtitle": "Nur 5 Autominuten vom Gelände entfernt",
+    "introHeading": "Die Landesgartenschau direkt vor unserer Tür",
+    "eventDates": "23. April – 11. Oktober 2026",
+    "distance": "5 Min. entfernt",
+    "ourRoomsHeading": "Unsere Zimmer für Ihren LGS-Aufenthalt",
+    "bookNow": "Jetzt Zimmer sichern"
+  },
+  "ferienwohnungen": {
+    "title": "Ferienwohnungen im Eichsfeld",
+    "subtitle": "Voll ausgestattete Küche, Terrasse & Garten",
+    "intro": "Unsere beiden Ferienwohnungen bieten Ihnen viel Platz, eine komplett ausgestattete Küche und direkten Zugang zu unserem 25.000 m² großen Garten. Ideal für Familien und längere Aufenthalte.",
+    "highlights": "Ausstattungs-Highlights",
+    "kitchen": "Voll ausgestattete Küche",
+    "terrace": "Eigene Terrasse",
+    "garden": "25.000 m² Garten",
+    "parking": "Kostenloser Parkplatz",
+    "bookNow": "Ferienwohnung buchen"
+  },
+  "monteurzimmer": {
+    "title": "Monteurzimmer in Leinefelde-Worbis",
+    "subtitle": "Günstig, komfortabel & verkehrsgünstig gelegen",
+    "intro": "Sie arbeiten in Leinefelde-Worbis oder im Eichsfeld? Unsere Pension bietet komfortable Zimmer für Monteure, Handwerker und Geschäftsreisende – mit kostenlosem WLAN, Parkplatz und Küchenzugang.",
+    "highlights": "Ihre Vorteile",
+    "wifi": "Kostenloses WLAN",
+    "parking": "Kostenloser Parkplatz",
+    "kitchen": "Küchenzugang",
+    "location": "Nahe A38 & Leinefelde",
+    "quiet": "Ruhige Lage im Grünen",
+    "weekly": "Attraktive Wochenpreise auf Anfrage",
+    "bookNow": "Zimmer anfragen"
   }
 }

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -290,5 +290,43 @@
     "foehn": "Hair dryer",
     "tisch": "Small table",
     "heizung": "Heating"
+  },
+  "lgs": {
+    "bannerTitle": "State Garden Show 2026",
+    "countdown": "{days} days to go",
+    "countdownOne": "1 day to go",
+    "liveNow": "Experience it now!",
+    "linkText": "Book accommodation",
+    "pageTitle": "Accommodation for the State Garden Show 2026",
+    "pageSubtitle": "Just a 5-minute drive from the venue",
+    "introHeading": "The State Garden Show right on our doorstep",
+    "eventDates": "April 23 – October 11, 2026",
+    "distance": "5 min. away",
+    "ourRoomsHeading": "Our rooms for your garden show stay",
+    "bookNow": "Book a room now"
+  },
+  "ferienwohnungen": {
+    "title": "Holiday Apartments in the Eichsfeld",
+    "subtitle": "Fully equipped kitchen, terrace & garden",
+    "intro": "Our two holiday apartments offer plenty of space, a fully equipped kitchen, and direct access to our 25,000 m² garden. Ideal for families and longer stays.",
+    "highlights": "Highlights",
+    "kitchen": "Fully equipped kitchen",
+    "terrace": "Private terrace",
+    "garden": "25,000 m² garden",
+    "parking": "Free parking",
+    "bookNow": "Book apartment"
+  },
+  "monteurzimmer": {
+    "title": "Worker Accommodation in Leinefelde-Worbis",
+    "subtitle": "Affordable, comfortable & conveniently located",
+    "intro": "Working in Leinefelde-Worbis or the Eichsfeld region? Our guesthouse offers comfortable rooms for tradespeople, craftsmen, and business travellers – with free WiFi, parking, and kitchen access.",
+    "highlights": "Your benefits",
+    "wifi": "Free WiFi",
+    "parking": "Free parking",
+    "kitchen": "Kitchen access",
+    "location": "Near A38 & Leinefelde",
+    "quiet": "Quiet location in nature",
+    "weekly": "Attractive weekly rates on request",
+    "bookNow": "Enquire about rooms"
   }
 }

--- a/app/pages/aktivitaeten/radfahren.vue
+++ b/app/pages/aktivitaeten/radfahren.vue
@@ -34,6 +34,16 @@ useHead({
       hreflang: 'de',
       href: 'https://www.pension-volgenandt.de/aktivitaeten/radfahren/',
     },
+    {
+      rel: 'alternate',
+      hreflang: 'en',
+      href: 'https://www.pension-volgenandt.de/en/activities/cycling/',
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: 'https://www.pension-volgenandt.de/aktivitaeten/radfahren/',
+    },
   ],
 })
 

--- a/app/pages/aktivitaeten/wandern.vue
+++ b/app/pages/aktivitaeten/wandern.vue
@@ -34,6 +34,16 @@ useHead({
       hreflang: 'de',
       href: 'https://www.pension-volgenandt.de/aktivitaeten/wandern/',
     },
+    {
+      rel: 'alternate',
+      hreflang: 'en',
+      href: 'https://www.pension-volgenandt.de/en/activities/hiking/',
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: 'https://www.pension-volgenandt.de/aktivitaeten/wandern/',
+    },
   ],
 })
 

--- a/app/pages/aktuelles/[slug].vue
+++ b/app/pages/aktuelles/[slug].vue
@@ -13,6 +13,13 @@ if (!article.value) {
   throw createError({ statusCode: 404, message: t('news.notFound', locale.value) })
 }
 
+// Optional: load rooms for event articles with showRooms flag
+const { data: rooms } = await useAsyncData(
+  `news-rooms-${slug}`,
+  () => queryCollection('rooms').order('sortOrder', 'ASC').all(),
+  { immediate: article.value.showRooms },
+)
+
 useSeoMeta({
   title: article.value.seoTitle,
   ogTitle: article.value.seoTitle,
@@ -34,11 +41,21 @@ useHead({
       hreflang: 'de',
       href: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
     },
+    {
+      rel: 'alternate',
+      hreflang: 'en',
+      href: `https://www.pension-volgenandt.de/en/news/${article.value.slug}/`,
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
+    },
   ],
 })
 
 // Article structured data
-useSchemaOrg([
+const schemaItems: Record<string, unknown>[] = [
   {
     '@type': 'NewsArticle',
     headline: article.value.seoTitle,
@@ -50,7 +67,44 @@ useSchemaOrg([
       name: 'Pension Volgenandt',
     },
   },
-])
+]
+
+// Add Event schema when event dates are present
+if (article.value.eventStartDate && article.value.eventEndDate) {
+  schemaItems.push({
+    '@type': 'Event',
+    name: article.value.title,
+    startDate: article.value.eventStartDate,
+    endDate: article.value.eventEndDate,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: {
+      '@type': 'Place',
+      name: 'Landesgartenschau Leinefelde-Worbis',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Leinefelde-Worbis',
+        addressRegion: 'Thüringen',
+        addressCountry: 'DE',
+      },
+    },
+    organizer: {
+      '@type': 'Organization',
+      name: 'Landesgartenschau Leinefelde-Worbis 2026 gGmbH',
+      url: 'https://www.lgs-leinefelde-worbis.de/',
+    },
+    offers: {
+      '@type': 'Offer',
+      name: t('lgs.pageTitle', locale.value),
+      url: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
+      priceCurrency: 'EUR',
+      price: '50',
+      availability: 'https://schema.org/InStock',
+    },
+  })
+}
+
+useSchemaOrg(schemaItems)
 
 definePageMeta({
   breadcrumb: { label: 'Artikel' },
@@ -118,6 +172,39 @@ function formatDate(dateStr: string) {
         >
           {{ paragraph }}
         </p>
+      </section>
+
+      <!-- Room cards (for event articles with showRooms) -->
+      <section v-if="article.showRooms && rooms?.length" class="mb-10">
+        <h2 class="mb-6 font-serif text-xl font-semibold text-sage-900">
+          {{ t('lgs.ourRoomsHeading', locale) }}
+        </h2>
+        <div class="grid gap-6 sm:grid-cols-2">
+          <RoomsCard
+            v-for="room in rooms"
+            :key="room.slug"
+            :name="room.name"
+            :slug="room.slug"
+            :short-description="room.shortDescription"
+            :hero-image="room.heroImage"
+            :hero-image-alt="room.heroImageAlt"
+            :starting-price="room.startingPrice"
+            :max-guests="room.maxGuests"
+            :highlights="room.highlights"
+            :beds24-property-id="room.beds24PropertyId"
+            :beds24-room-id="room.beds24RoomId"
+            :locale="locale"
+            compact
+          />
+        </div>
+        <div class="mt-6 text-center">
+          <NuxtLink
+            :to="locale === 'en' ? '/en/rooms/' : '/zimmer/'"
+            class="inline-block rounded-lg bg-waldhonig-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-waldhonig-600"
+          >
+            {{ t('lgs.bookNow', locale) }}
+          </NuxtLink>
+        </div>
       </section>
 
       <!-- External links -->

--- a/app/pages/ausflugsziele/[slug].vue
+++ b/app/pages/ausflugsziele/[slug].vue
@@ -37,6 +37,16 @@ useHead({
       hreflang: 'de',
       href: `https://www.pension-volgenandt.de/ausflugsziele/${attraction.value.slug}/`,
     },
+    {
+      rel: 'alternate',
+      hreflang: 'en',
+      href: `https://www.pension-volgenandt.de/en/attractions/${attraction.value.slug}/`,
+    },
+    {
+      rel: 'alternate',
+      hreflang: 'x-default',
+      href: `https://www.pension-volgenandt.de/ausflugsziele/${attraction.value.slug}/`,
+    },
   ],
 })
 

--- a/app/pages/en/holiday-apartments.vue
+++ b/app/pages/en/holiday-apartments.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { t } from '~/utils/translations'
+
+const siteUrl = 'https://www.pension-volgenandt.de'
+
+useSeoMeta({
+  title: 'Holiday Apartments Eichsfeld | Pension Volgenandt',
+  ogTitle: 'Holiday Apartments Eichsfeld | Pension Volgenandt',
+  description:
+    'Self-catering holiday apartments near Leinefelde-Worbis, Thuringia. Fully equipped kitchen, terrace & garden. 2–6 guests, from 73 €/night.',
+  ogDescription:
+    'Self-catering holiday apartments near Leinefelde-Worbis, Thuringia. Fully equipped kitchen, terrace & garden. 2–6 guests, from 73 €/night.',
+  ogImage: `${siteUrl}/img/hero/hero-poster.webp`,
+  ogType: 'website',
+})
+
+useHead({
+  htmlAttrs: { lang: 'en' },
+  titleTemplate: '%s',
+  link: [
+    { rel: 'canonical', href: `${siteUrl}/en/holiday-apartments/` },
+    { rel: 'alternate', hreflang: 'de', href: `${siteUrl}/ferienwohnungen/` },
+    { rel: 'alternate', hreflang: 'en', href: `${siteUrl}/en/holiday-apartments/` },
+    { rel: 'alternate', hreflang: 'x-default', href: `${siteUrl}/ferienwohnungen/` },
+  ],
+})
+
+useSchemaOrg([
+  {
+    '@type': 'LodgingBusiness',
+    name: 'Pension Volgenandt – Holiday Apartments',
+    description:
+      'Holiday apartments in the Eichsfeld region near Leinefelde-Worbis with kitchen, terrace, and 25,000 m² garden.',
+    url: `${siteUrl}/en/holiday-apartments/`,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Breitenbach 12',
+      addressLocality: 'Leinefelde-Worbis',
+      postalCode: '37327',
+      addressRegion: 'Thuringia',
+      addressCountry: 'DE',
+    },
+  },
+])
+
+const { data: rooms } = await useAsyncData('ferienwohnungen-en', () =>
+  queryCollection('roomsEn').where('type', '=', 'ferienwohnung').order('sortOrder', 'ASC').all(),
+)
+</script>
+
+<template>
+  <div>
+    <SharedPageBanner
+      image="/img/content/landesgartenschau-2026.webp"
+      :image-alt="t('ferienwohnungen.title', 'en')"
+      :title="t('ferienwohnungen.title', 'en')"
+      :subtitle="t('ferienwohnungen.subtitle', 'en')"
+    />
+
+    <div class="mx-auto max-w-5xl px-6 py-12 md:py-16">
+      <!-- Intro -->
+      <section class="mx-auto mb-12 max-w-3xl text-center">
+        <p class="text-lg leading-relaxed text-sage-700">
+          {{ t('ferienwohnungen.intro', 'en') }}
+        </p>
+      </section>
+
+      <!-- Highlights -->
+      <section class="mb-12">
+        <h2 class="mb-6 text-center font-serif text-xl font-semibold text-sage-900">
+          {{ t('ferienwohnungen.highlights', 'en') }}
+        </h2>
+        <div class="mx-auto grid max-w-2xl grid-cols-2 gap-4 md:grid-cols-4">
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:cooking-pot" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.kitchen', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:sun-horizon" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.terrace', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:tree" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.garden', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:car" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.parking', 'en')
+            }}</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Room cards -->
+      <section v-if="rooms?.length" class="mb-12">
+        <div class="grid gap-8 md:grid-cols-2">
+          <RoomsCard
+            v-for="room in rooms"
+            :key="room.slug"
+            :name="room.name"
+            :slug="room.slug"
+            :short-description="room.shortDescription"
+            :hero-image="room.heroImage"
+            :hero-image-alt="room.heroImageAlt"
+            :starting-price="room.startingPrice"
+            :max-guests="room.maxGuests"
+            :highlights="room.highlights"
+            :beds24-property-id="room.beds24PropertyId"
+            :beds24-room-id="room.beds24RoomId"
+            locale="en"
+          />
+        </div>
+      </section>
+    </div>
+
+    <SharedSoftCta :text="t('ferienwohnungen.bookNow', 'en')" />
+    <SharedBookingCta />
+  </div>
+</template>

--- a/app/pages/en/holiday-apartments.vue
+++ b/app/pages/en/holiday-apartments.vue
@@ -51,7 +51,7 @@ const { data: rooms } = await useAsyncData('ferienwohnungen-en', () =>
 <template>
   <div>
     <SharedPageBanner
-      image="/img/content/landesgartenschau-2026.webp"
+      image="/img/rooms/schoene-aussicht-wohnkueche.webp"
       :image-alt="t('ferienwohnungen.title', 'en')"
       :title="t('ferienwohnungen.title', 'en')"
       :subtitle="t('ferienwohnungen.subtitle', 'en')"

--- a/app/pages/en/index.vue
+++ b/app/pages/en/index.vue
@@ -28,6 +28,10 @@ useSeoMeta({
   <div>
     <HomeHeroVideo />
 
+    <ClientOnly>
+      <HomeHeroLgsBannerMobile />
+    </ClientOnly>
+
     <UiScrollReveal>
       <HomeWelcome />
     </UiScrollReveal>

--- a/app/pages/en/news/[slug].vue
+++ b/app/pages/en/news/[slug].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { t } from '~/utils/translations'
+
 const route = useRoute()
 const slug = route.params.slug as string
 
@@ -171,7 +173,9 @@ function formatDate(dateStr: string) {
 
       <!-- Room cards (for event articles with showRooms) -->
       <section v-if="article.showRooms && rooms?.length" class="mb-10">
-        <h2 class="mb-6 font-serif text-xl font-semibold text-sage-900">Our rooms for your stay</h2>
+        <h2 class="mb-6 font-serif text-xl font-semibold text-sage-900">
+          {{ t('lgs.ourRoomsHeading', 'en') }}
+        </h2>
         <div class="grid gap-6 sm:grid-cols-2">
           <RoomsCard
             v-for="room in rooms"
@@ -195,7 +199,7 @@ function formatDate(dateStr: string) {
             to="/en/rooms/"
             class="inline-block rounded-lg bg-waldhonig-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-waldhonig-600"
           >
-            Book a room now
+            {{ t('lgs.bookNow', 'en') }}
           </NuxtLink>
         </div>
       </section>

--- a/app/pages/en/news/[slug].vue
+++ b/app/pages/en/news/[slug].vue
@@ -10,6 +10,13 @@ if (!article.value) {
   throw createError({ statusCode: 404, message: 'Article not found' })
 }
 
+// Optional: load rooms for event articles with showRooms flag
+const { data: rooms } = await useAsyncData(
+  `news-en-rooms-${slug}`,
+  () => queryCollection('roomsEn').order('sortOrder', 'ASC').all(),
+  { immediate: article.value.showRooms },
+)
+
 useSeoMeta({
   title: article.value.seoTitle,
   ogTitle: article.value.seoTitle,
@@ -46,7 +53,7 @@ useHead({
 })
 
 // Article structured data
-useSchemaOrg([
+const schemaItems: Record<string, unknown>[] = [
   {
     '@type': 'NewsArticle',
     headline: article.value.seoTitle,
@@ -58,7 +65,44 @@ useSchemaOrg([
       name: 'Pension Volgenandt',
     },
   },
-])
+]
+
+// Add Event schema when event dates are present
+if (article.value.eventStartDate && article.value.eventEndDate) {
+  schemaItems.push({
+    '@type': 'Event',
+    name: article.value.title,
+    startDate: article.value.eventStartDate,
+    endDate: article.value.eventEndDate,
+    eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+    eventStatus: 'https://schema.org/EventScheduled',
+    location: {
+      '@type': 'Place',
+      name: 'State Garden Show Leinefelde-Worbis',
+      address: {
+        '@type': 'PostalAddress',
+        addressLocality: 'Leinefelde-Worbis',
+        addressRegion: 'Thuringia',
+        addressCountry: 'DE',
+      },
+    },
+    organizer: {
+      '@type': 'Organization',
+      name: 'Landesgartenschau Leinefelde-Worbis 2026 gGmbH',
+      url: 'https://www.lgs-leinefelde-worbis.de/',
+    },
+    offers: {
+      '@type': 'Offer',
+      name: 'Accommodation for the State Garden Show 2026',
+      url: `https://www.pension-volgenandt.de/en/news/${article.value.slug}/`,
+      priceCurrency: 'EUR',
+      price: '50',
+      availability: 'https://schema.org/InStock',
+    },
+  })
+}
+
+useSchemaOrg(schemaItems)
 
 definePageMeta({
   breadcrumb: { label: 'Article' },
@@ -123,6 +167,37 @@ function formatDate(dateStr: string) {
         >
           {{ paragraph }}
         </p>
+      </section>
+
+      <!-- Room cards (for event articles with showRooms) -->
+      <section v-if="article.showRooms && rooms?.length" class="mb-10">
+        <h2 class="mb-6 font-serif text-xl font-semibold text-sage-900">Our rooms for your stay</h2>
+        <div class="grid gap-6 sm:grid-cols-2">
+          <RoomsCard
+            v-for="room in rooms"
+            :key="room.slug"
+            :name="room.name"
+            :slug="room.slug"
+            :short-description="room.shortDescription"
+            :hero-image="room.heroImage"
+            :hero-image-alt="room.heroImageAlt"
+            :starting-price="room.startingPrice"
+            :max-guests="room.maxGuests"
+            :highlights="room.highlights"
+            :beds24-property-id="room.beds24PropertyId"
+            :beds24-room-id="room.beds24RoomId"
+            locale="en"
+            compact
+          />
+        </div>
+        <div class="mt-6 text-center">
+          <NuxtLink
+            to="/en/rooms/"
+            class="inline-block rounded-lg bg-waldhonig-500 px-6 py-3 font-semibold text-white transition-colors hover:bg-waldhonig-600"
+          >
+            Book a room now
+          </NuxtLink>
+        </div>
       </section>
 
       <!-- External links -->

--- a/app/pages/en/rooms/[slug].vue
+++ b/app/pages/en/rooms/[slug].vue
@@ -74,17 +74,16 @@ useHead({
   ],
 })
 
+const fallbackDescription =
+  room.value.shortDescription.length > 155
+    ? `${room.value.shortDescription.slice(0, 152)}...`
+    : room.value.shortDescription
+
 useSeoMeta({
-  title: room.value.name,
-  ogTitle: `${room.value.name} | Pension Volgenandt`,
-  description:
-    room.value.shortDescription.length > 155
-      ? `${room.value.shortDescription.slice(0, 152)}...`
-      : room.value.shortDescription,
-  ogDescription:
-    room.value.shortDescription.length > 155
-      ? `${room.value.shortDescription.slice(0, 152)}...`
-      : room.value.shortDescription,
+  title: room.value.seoTitle ?? room.value.name,
+  ogTitle: room.value.seoTitle ?? `${room.value.name} | Pension Volgenandt`,
+  description: room.value.seoDescription ?? fallbackDescription,
+  ogDescription: room.value.seoDescription ?? fallbackDescription,
   ogImage: `${siteUrl}${room.value.heroImage}`,
   ogType: 'website',
 })

--- a/app/pages/en/worker-rooms.vue
+++ b/app/pages/en/worker-rooms.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { t } from '~/utils/translations'
+
+const siteUrl = 'https://www.pension-volgenandt.de'
+
+useSeoMeta({
+  title: 'Worker Accommodation Leinefelde | Pension Volgenandt',
+  ogTitle: 'Worker Accommodation Leinefelde | Pension Volgenandt',
+  description:
+    'Affordable worker rooms near Leinefelde-Worbis, Thuringia. Free WiFi, parking & kitchen access. Ideal for tradespeople. From 50 €/night.',
+  ogDescription:
+    'Affordable worker rooms near Leinefelde-Worbis, Thuringia. Free WiFi, parking & kitchen access. Ideal for tradespeople. From 50 €/night.',
+  ogImage: `${siteUrl}/img/hero/hero-poster.webp`,
+  ogType: 'website',
+})
+
+useHead({
+  htmlAttrs: { lang: 'en' },
+  titleTemplate: '%s',
+  link: [
+    { rel: 'canonical', href: `${siteUrl}/en/worker-rooms/` },
+    { rel: 'alternate', hreflang: 'de', href: `${siteUrl}/monteurzimmer/` },
+    { rel: 'alternate', hreflang: 'en', href: `${siteUrl}/en/worker-rooms/` },
+    { rel: 'alternate', hreflang: 'x-default', href: `${siteUrl}/monteurzimmer/` },
+  ],
+})
+
+useSchemaOrg([
+  {
+    '@type': 'LodgingBusiness',
+    name: 'Pension Volgenandt – Worker Accommodation',
+    description:
+      'Worker and business rooms in Leinefelde-Worbis. Affordable, comfortable, with WiFi and parking.',
+    url: `${siteUrl}/en/worker-rooms/`,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Breitenbach 12',
+      addressLocality: 'Leinefelde-Worbis',
+      postalCode: '37327',
+      addressRegion: 'Thuringia',
+      addressCountry: 'DE',
+    },
+    audience: {
+      '@type': 'Audience',
+      audienceType: 'Business travelers',
+    },
+  },
+])
+
+const { data: rooms } = await useAsyncData('monteurzimmer-en', () =>
+  queryCollection('roomsEn').order('sortOrder', 'ASC').all(),
+)
+</script>
+
+<template>
+  <div>
+    <SharedPageBanner
+      image="/img/hero/hero-poster.webp"
+      :image-alt="t('monteurzimmer.title', 'en')"
+      :title="t('monteurzimmer.title', 'en')"
+      :subtitle="t('monteurzimmer.subtitle', 'en')"
+    />
+
+    <div class="mx-auto max-w-5xl px-6 py-12 md:py-16">
+      <!-- Intro -->
+      <section class="mx-auto mb-12 max-w-3xl text-center">
+        <p class="text-lg leading-relaxed text-sage-700">
+          {{ t('monteurzimmer.intro', 'en') }}
+        </p>
+      </section>
+
+      <!-- Benefits -->
+      <section class="mb-12">
+        <h2 class="mb-6 text-center font-serif text-xl font-semibold text-sage-900">
+          {{ t('monteurzimmer.highlights', 'en') }}
+        </h2>
+        <div class="mx-auto grid max-w-3xl grid-cols-2 gap-4 md:grid-cols-3">
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:wifi-high" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.wifi', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:car" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.parking', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:cooking-pot" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.kitchen', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:map-pin" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.location', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:tree" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.quiet', 'en')
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:calendar-check" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.weekly', 'en')
+            }}</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Room cards -->
+      <section v-if="rooms?.length" class="mb-12">
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <RoomsCard
+            v-for="room in rooms"
+            :key="room.slug"
+            :name="room.name"
+            :slug="room.slug"
+            :short-description="room.shortDescription"
+            :hero-image="room.heroImage"
+            :hero-image-alt="room.heroImageAlt"
+            :starting-price="room.startingPrice"
+            :max-guests="room.maxGuests"
+            :highlights="room.highlights"
+            :beds24-property-id="room.beds24PropertyId"
+            :beds24-room-id="room.beds24RoomId"
+            locale="en"
+          />
+        </div>
+      </section>
+    </div>
+
+    <SharedSoftCta :text="t('monteurzimmer.bookNow', 'en')" />
+    <SharedBookingCta />
+  </div>
+</template>

--- a/app/pages/ferienwohnungen.vue
+++ b/app/pages/ferienwohnungen.vue
@@ -1,0 +1,126 @@
+<script setup lang="ts">
+import { t } from '~/utils/translations'
+
+const { locale } = useLocale()
+const siteUrl = 'https://www.pension-volgenandt.de'
+
+useSeoMeta({
+  title: 'Ferienwohnung Eichsfeld | Pension Volgenandt Leinefelde',
+  ogTitle: 'Ferienwohnung Eichsfeld | Pension Volgenandt Leinefelde',
+  description:
+    'Ferienwohnungen im Eichsfeld bei Leinefelde-Worbis. Voll ausgestattete Küche, Terrasse & Garten. 2–6 Gäste, ab 73 €/Nacht.',
+  ogDescription:
+    'Ferienwohnungen im Eichsfeld bei Leinefelde-Worbis. Voll ausgestattete Küche, Terrasse & Garten. 2–6 Gäste, ab 73 €/Nacht.',
+  ogImage: `${siteUrl}/img/hero/hero-poster.webp`,
+  ogType: 'website',
+})
+
+useHead({
+  titleTemplate: '%s',
+  link: [
+    { rel: 'canonical', href: `${siteUrl}/ferienwohnungen/` },
+    { rel: 'alternate', hreflang: 'de', href: `${siteUrl}/ferienwohnungen/` },
+    { rel: 'alternate', hreflang: 'en', href: `${siteUrl}/en/holiday-apartments/` },
+    { rel: 'alternate', hreflang: 'x-default', href: `${siteUrl}/ferienwohnungen/` },
+  ],
+})
+
+useSchemaOrg([
+  {
+    '@type': 'LodgingBusiness',
+    name: 'Pension Volgenandt – Ferienwohnungen',
+    description:
+      'Ferienwohnungen im Eichsfeld bei Leinefelde-Worbis mit Küche, Terrasse und 25.000 m² Garten.',
+    url: `${siteUrl}/ferienwohnungen/`,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Breitenbach 12',
+      addressLocality: 'Leinefelde-Worbis',
+      postalCode: '37327',
+      addressRegion: 'Thüringen',
+      addressCountry: 'DE',
+    },
+  },
+])
+
+const { data: rooms } = await useAsyncData('ferienwohnungen', () =>
+  queryCollection('rooms').where('type', '=', 'ferienwohnung').order('sortOrder', 'ASC').all(),
+)
+</script>
+
+<template>
+  <div>
+    <SharedPageBanner
+      image="/img/content/landesgartenschau-2026.webp"
+      :image-alt="t('ferienwohnungen.title', locale)"
+      :title="t('ferienwohnungen.title', locale)"
+      :subtitle="t('ferienwohnungen.subtitle', locale)"
+    />
+
+    <div class="mx-auto max-w-5xl px-6 py-12 md:py-16">
+      <!-- Intro -->
+      <section class="mx-auto mb-12 max-w-3xl text-center">
+        <p class="text-lg leading-relaxed text-sage-700">
+          {{ t('ferienwohnungen.intro', locale) }}
+        </p>
+      </section>
+
+      <!-- Highlights -->
+      <section class="mb-12">
+        <h2 class="mb-6 text-center font-serif text-xl font-semibold text-sage-900">
+          {{ t('ferienwohnungen.highlights', locale) }}
+        </h2>
+        <div class="mx-auto grid max-w-2xl grid-cols-2 gap-4 md:grid-cols-4">
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:cooking-pot" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.kitchen', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:sun-horizon" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.terrace', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:tree" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.garden', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:car" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('ferienwohnungen.parking', locale)
+            }}</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Room cards -->
+      <section v-if="rooms?.length" class="mb-12">
+        <div class="grid gap-8 md:grid-cols-2">
+          <RoomsCard
+            v-for="room in rooms"
+            :key="room.slug"
+            :name="room.name"
+            :slug="room.slug"
+            :short-description="room.shortDescription"
+            :hero-image="room.heroImage"
+            :hero-image-alt="room.heroImageAlt"
+            :starting-price="room.startingPrice"
+            :max-guests="room.maxGuests"
+            :highlights="room.highlights"
+            :beds24-property-id="room.beds24PropertyId"
+            :beds24-room-id="room.beds24RoomId"
+            :locale="locale"
+          />
+        </div>
+      </section>
+    </div>
+
+    <SharedSoftCta :text="t('ferienwohnungen.bookNow', locale)" />
+    <SharedBookingCta />
+  </div>
+</template>

--- a/app/pages/ferienwohnungen.vue
+++ b/app/pages/ferienwohnungen.vue
@@ -51,7 +51,7 @@ const { data: rooms } = await useAsyncData('ferienwohnungen', () =>
 <template>
   <div>
     <SharedPageBanner
-      image="/img/content/landesgartenschau-2026.webp"
+      image="/img/rooms/schoene-aussicht-wohnkueche.webp"
       :image-alt="t('ferienwohnungen.title', locale)"
       :title="t('ferienwohnungen.title', locale)"
       :subtitle="t('ferienwohnungen.subtitle', locale)"

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -29,6 +29,10 @@ useHead({
 
     <HomeHeroVideo />
 
+    <ClientOnly>
+      <HomeHeroLgsBannerMobile />
+    </ClientOnly>
+
     <UiScrollReveal>
       <HomeWelcome />
     </UiScrollReveal>

--- a/app/pages/monteurzimmer.vue
+++ b/app/pages/monteurzimmer.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import { t } from '~/utils/translations'
+
+const { locale } = useLocale()
+const siteUrl = 'https://www.pension-volgenandt.de'
+
+useSeoMeta({
+  title: 'Monteurzimmer Leinefelde | Pension Volgenandt Eichsfeld',
+  ogTitle: 'Monteurzimmer Leinefelde | Pension Volgenandt Eichsfeld',
+  description:
+    'Günstige Monteurzimmer in Leinefelde-Worbis. WLAN, Parkplatz, Küchenzugang – ideal für Handwerker & Firmen. Ab 50 €/Nacht.',
+  ogDescription:
+    'Günstige Monteurzimmer in Leinefelde-Worbis. WLAN, Parkplatz, Küchenzugang – ideal für Handwerker & Firmen. Ab 50 €/Nacht.',
+  ogImage: `${siteUrl}/img/hero/hero-poster.webp`,
+  ogType: 'website',
+})
+
+useHead({
+  titleTemplate: '%s',
+  link: [
+    { rel: 'canonical', href: `${siteUrl}/monteurzimmer/` },
+    { rel: 'alternate', hreflang: 'de', href: `${siteUrl}/monteurzimmer/` },
+    { rel: 'alternate', hreflang: 'en', href: `${siteUrl}/en/worker-rooms/` },
+    { rel: 'alternate', hreflang: 'x-default', href: `${siteUrl}/monteurzimmer/` },
+  ],
+})
+
+useSchemaOrg([
+  {
+    '@type': 'LodgingBusiness',
+    name: 'Pension Volgenandt – Monteurzimmer',
+    description:
+      'Monteurzimmer und Firmenzimmer in Leinefelde-Worbis. Günstig, komfortabel, mit WLAN und Parkplatz.',
+    url: `${siteUrl}/monteurzimmer/`,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Breitenbach 12',
+      addressLocality: 'Leinefelde-Worbis',
+      postalCode: '37327',
+      addressRegion: 'Thüringen',
+      addressCountry: 'DE',
+    },
+    audience: {
+      '@type': 'Audience',
+      audienceType: 'Business travelers',
+    },
+  },
+])
+
+const { data: rooms } = await useAsyncData('monteurzimmer', () =>
+  queryCollection('rooms').order('sortOrder', 'ASC').all(),
+)
+</script>
+
+<template>
+  <div>
+    <SharedPageBanner
+      image="/img/hero/hero-poster.webp"
+      :image-alt="t('monteurzimmer.title', locale)"
+      :title="t('monteurzimmer.title', locale)"
+      :subtitle="t('monteurzimmer.subtitle', locale)"
+    />
+
+    <div class="mx-auto max-w-5xl px-6 py-12 md:py-16">
+      <!-- Intro -->
+      <section class="mx-auto mb-12 max-w-3xl text-center">
+        <p class="text-lg leading-relaxed text-sage-700">
+          {{ t('monteurzimmer.intro', locale) }}
+        </p>
+      </section>
+
+      <!-- Benefits -->
+      <section class="mb-12">
+        <h2 class="mb-6 text-center font-serif text-xl font-semibold text-sage-900">
+          {{ t('monteurzimmer.highlights', locale) }}
+        </h2>
+        <div class="mx-auto grid max-w-3xl grid-cols-2 gap-4 md:grid-cols-3">
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:wifi-high" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.wifi', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:car" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.parking', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:cooking-pot" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.kitchen', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:map-pin" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.location', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:tree" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.quiet', locale)
+            }}</span>
+          </div>
+          <div class="flex flex-col items-center gap-2 rounded-lg bg-sage-50 p-4 text-center">
+            <Icon name="ph:calendar-check" class="size-6 text-waldhonig-500" />
+            <span class="text-sm font-medium text-sage-700">{{
+              t('monteurzimmer.weekly', locale)
+            }}</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- Room cards -->
+      <section v-if="rooms?.length" class="mb-12">
+        <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          <RoomsCard
+            v-for="room in rooms"
+            :key="room.slug"
+            :name="room.name"
+            :slug="room.slug"
+            :short-description="room.shortDescription"
+            :hero-image="room.heroImage"
+            :hero-image-alt="room.heroImageAlt"
+            :starting-price="room.startingPrice"
+            :max-guests="room.maxGuests"
+            :highlights="room.highlights"
+            :beds24-property-id="room.beds24PropertyId"
+            :beds24-room-id="room.beds24RoomId"
+            :locale="locale"
+          />
+        </div>
+      </section>
+    </div>
+
+    <SharedSoftCta :text="t('monteurzimmer.bookNow', locale)" />
+    <SharedBookingCta />
+  </div>
+</template>

--- a/app/pages/zimmer/[slug].vue
+++ b/app/pages/zimmer/[slug].vue
@@ -44,17 +44,16 @@ const bookingUrl = computed(() => {
 })
 
 // Dynamic SEO meta
+const fallbackDescription =
+  room.value.shortDescription.length > 155
+    ? `${room.value.shortDescription.slice(0, 152)}...`
+    : room.value.shortDescription
+
 useSeoMeta({
-  title: room.value.name,
-  ogTitle: `${room.value.name} | Pension Volgenandt`,
-  description:
-    room.value.shortDescription.length > 155
-      ? `${room.value.shortDescription.slice(0, 152)}...`
-      : room.value.shortDescription,
-  ogDescription:
-    room.value.shortDescription.length > 155
-      ? `${room.value.shortDescription.slice(0, 152)}...`
-      : room.value.shortDescription,
+  title: room.value.seoTitle ?? room.value.name,
+  ogTitle: room.value.seoTitle ?? `${room.value.name} | Pension Volgenandt`,
+  description: room.value.seoDescription ?? fallbackDescription,
+  ogDescription: room.value.seoDescription ?? fallbackDescription,
   ogImage: `https://www.pension-volgenandt.de${room.value.heroImage}`,
   ogType: 'website',
 })

--- a/content.config.ts
+++ b/content.config.ts
@@ -46,6 +46,8 @@ const roomSchema = z.object({
   // Identity
   name: z.string(),
   slug: z.string(),
+  seoTitle: z.string().max(60).optional(),
+  seoDescription: z.string().max(155).optional(),
   type: z.enum(['ferienwohnung', 'doppelzimmer', 'zweibettzimmer', 'einzelzimmer']),
   category: z.string(),
   shortDescription: z.string(),
@@ -201,6 +203,11 @@ const newsSchema = z.object({
     )
     .default([]),
   sortOrder: z.number().default(0),
+
+  // Optional: show room cards on event articles
+  showRooms: z.boolean().default(false),
+  eventStartDate: z.string().optional(),
+  eventEndDate: z.string().optional(),
 })
 
 // Picknick schemas

--- a/content/activities-en/radfahren.yml
+++ b/content/activities-en/radfahren.yml
@@ -1,7 +1,7 @@
 name: 'Cycling & Leine Cycle Route'
 slug: radfahren
-seoTitle: 'Cycling in the Eichsfeld'
-seoDescription: 'Cycle tours in the Eichsfeld and along the Leine Cycle Route. Our guesthouse is the ideal starting point for cyclists in Thuringia.'
+seoTitle: 'Cycling in Eichsfeld – Stay on the Leine Cycle Path'
+seoDescription: 'Cycling tours in Eichsfeld & along the Leine Cycle Path. Pension Volgenandt – the ideal base for cyclists in Thuringia.'
 heroImage: /img/garten/umgebung-felder-abendsonne.webp
 heroImageAlt: 'Cyclist on the Leine Cycle Route in the Eichsfeld'
 intro: >-

--- a/content/activities-en/wandern.yml
+++ b/content/activities-en/wandern.yml
@@ -1,7 +1,7 @@
 name: 'Hiking in the Eichsfeld'
 slug: wandern
-seoTitle: 'Hiking in the Eichsfeld'
-seoDescription: 'Discover the most beautiful hiking trails in the Eichsfeld around our guesthouse. Routes, tips, and tour suggestions for every level.'
+seoTitle: 'Hiking in Eichsfeld – Accommodation | Pension Volgenandt'
+seoDescription: 'Hiking holiday in Eichsfeld, Thuringia. Best trails near Breitenbach. Pension with rooms & apartments as your hiking base.'
 heroImage: /img/homepage/aussicht-panorama.webp
 heroImageAlt: 'Hiking trail through the hilly Eichsfeld landscape'
 intro: >-

--- a/content/activities/radfahren.yml
+++ b/content/activities/radfahren.yml
@@ -1,7 +1,7 @@
 name: 'Radfahren & Leine-Radweg'
 slug: radfahren
-seoTitle: 'Radfahren im Eichsfeld'
-seoDescription: 'Radtouren im Eichsfeld und auf dem Leine-Radweg. Unsere Pension ist der ideale Ausgangspunkt für Radfahrer in Thüringen.'
+seoTitle: 'Radfahren im Eichsfeld – Unterkunft am Leine-Radweg'
+seoDescription: 'Radtouren im Eichsfeld & auf dem Leine-Radweg. Pension Volgenandt in Breitenbach – idealer Ausgangspunkt für Radfahrer.'
 heroImage: /img/garten/umgebung-felder-abendsonne.webp
 heroImageAlt: 'Radfahrer auf dem Leine-Radweg im Eichsfeld'
 intro: >-

--- a/content/activities/wandern.yml
+++ b/content/activities/wandern.yml
@@ -1,7 +1,7 @@
 name: 'Wandern im Eichsfeld'
 slug: wandern
-seoTitle: 'Wandern im Eichsfeld'
-seoDescription: 'Entdecken Sie die schönsten Wanderwege im Eichsfeld rund um unsere Pension. Routen, Tipps und Tourenvorschläge für jeden Anspruch.'
+seoTitle: 'Wandern im Eichsfeld – Unterkunft | Pension Volgenandt'
+seoDescription: 'Wanderurlaub im Eichsfeld: Die schönsten Wanderwege rund um Breitenbach. Pension mit Zimmer & Ferienwohnungen als Ausgangspunkt.'
 heroImage: /img/homepage/aussicht-panorama.webp
 heroImageAlt: 'Wanderweg durch die hügelige Landschaft des Eichsfelds'
 intro: >-

--- a/content/news-en/landesgartenschau-2026.yml
+++ b/content/news-en/landesgartenschau-2026.yml
@@ -1,9 +1,9 @@
 title: 'State Garden Show 2026 in Leinefelde-Worbis'
 slug: landesgartenschau-2026
-seoTitle: 'State Garden Show 2026 Leinefelde-Worbis – Stay'
+seoTitle: 'State Garden Show 2026 Accommodation | Pension Volgenandt'
 seoDescription: >-
-  The State Garden Show 2026 takes place right in Leinefelde-Worbis.
-  Stay at Pension Volgenandt – just minutes away.
+  Stay near the 2026 State Garden Show in Leinefelde-Worbis. Pension just
+  5 min away – apartments & rooms from 50 €/night.
 heroImage: '/img/content/landesgartenschau-2026.webp'
 heroImageAlt: 'State Garden Show 2026 in Leinefelde-Worbis'
 publishedDate: '2026-02-15'
@@ -51,3 +51,6 @@ externalLinks:
   - label: 'Information from the town of Leinefelde-Worbis'
     url: 'https://www.leinefelde-worbis.de/de/lgs-2026/landesgartenschau-2026/'
 sortOrder: 1
+showRooms: true
+eventStartDate: '2026-04-23'
+eventEndDate: '2026-10-11'

--- a/content/news/landesgartenschau-2026.yml
+++ b/content/news/landesgartenschau-2026.yml
@@ -1,9 +1,9 @@
 title: 'Landesgartenschau 2026 in Leinefelde-Worbis'
 slug: landesgartenschau-2026
-seoTitle: 'Landesgartenschau 2026 Leinefelde-Worbis – Übernachten'
+seoTitle: 'Landesgartenschau 2026 Unterkunft | Pension Volgenandt'
 seoDescription: >-
-  Die Landesgartenschau 2026 findet direkt in Leinefelde-Worbis statt.
-  Übernachten Sie in der Pension Volgenandt – nur wenige Minuten entfernt.
+  Übernachten Sie zur Landesgartenschau 2026 in Leinefelde-Worbis. Pension
+  nur 5 Min entfernt – Zimmer & Ferienwohnungen ab 50 €/Nacht.
 heroImage: '/img/content/landesgartenschau-2026.webp'
 heroImageAlt: 'Landesgartenschau 2026 in Leinefelde-Worbis'
 publishedDate: '2026-02-15'
@@ -52,3 +52,6 @@ externalLinks:
   - label: 'Informationen der Stadt Leinefelde-Worbis'
     url: 'https://www.leinefelde-worbis.de/de/lgs-2026/landesgartenschau-2026/'
 sortOrder: 1
+showRooms: true
+eventStartDate: '2026-04-23'
+eventEndDate: '2026-10-11'

--- a/content/rooms-en/balkonzimmer.yml
+++ b/content/rooms-en/balkonzimmer.yml
@@ -1,5 +1,7 @@
 name: 'Balcony Room'
 slug: balkonzimmer
+seoTitle: 'Balcony Room | Pension Volgenandt Eichsfeld'
+seoDescription: 'Twin room with private balcony in Breitenbach, Eichsfeld. Perfect for couples & solo travellers. From 60 €/night.'
 type: zweibettzimmer
 category: 'Doppelzimmer'
 shortDescription: >-

--- a/content/rooms-en/einzelzimmer.yml
+++ b/content/rooms-en/einzelzimmer.yml
@@ -1,5 +1,7 @@
 name: 'Single Room'
 slug: einzelzimmer
+seoTitle: 'Single Room Leinefelde | Pension Volgenandt'
+seoDescription: 'Comfortable single room for business & solo travellers in Breitenbach, Eichsfeld. From 50 €/night.'
 type: einzelzimmer
 category: 'Einzelzimmer'
 shortDescription: >-

--- a/content/rooms-en/emils-kuhwiese.yml
+++ b/content/rooms-en/emils-kuhwiese.yml
@@ -1,5 +1,7 @@
 name: "Holiday Apartment Emil's Kuhwiese"
 slug: emils-kuhwiese
+seoTitle: "Holiday Apartment Emil's Kuhwiese | Pension Volgenandt"
+seoDescription: 'Cosy holiday apartment with kitchen & terrace in Eichsfeld, Thuringia. Ideal for 2–3 guests. From 73 €/night.'
 type: ferienwohnung
 category: 'Ferienwohnung'
 shortDescription: >-

--- a/content/rooms-en/rosengarten.yml
+++ b/content/rooms-en/rosengarten.yml
@@ -1,5 +1,7 @@
 name: 'Rose Garden Room'
 slug: rosengarten
+seoTitle: 'Rose Garden Room | Pension Volgenandt Eichsfeld'
+seoDescription: 'Charming twin room overlooking the rose garden. Cosily furnished, ideal for 2 guests. From 60 €/night.'
 type: zweibettzimmer
 category: 'Doppelzimmer'
 shortDescription: >-

--- a/content/rooms-en/schoene-aussicht.yml
+++ b/content/rooms-en/schoene-aussicht.yml
@@ -1,5 +1,7 @@
 name: 'Holiday Apartment Schöne Aussicht'
 slug: schoene-aussicht
+seoTitle: 'Holiday Apartment Scenic View | Pension Volgenandt'
+seoDescription: 'Spacious holiday apartment with panoramic view in Eichsfeld. 2 bedrooms, kitchen, up to 6 guests. From 126 €/night.'
 type: ferienwohnung
 category: 'Ferienwohnung'
 shortDescription: >-

--- a/content/rooms-en/wohlfuehl-appartement.yml
+++ b/content/rooms-en/wohlfuehl-appartement.yml
@@ -1,5 +1,7 @@
 name: 'Comfort Apartment'
 slug: wohlfuehl-appartement
+seoTitle: 'Comfort Apartment | Pension Volgenandt Eichsfeld'
+seoDescription: 'Spacious room with fridge, kettle & sofa bed in Breitenbach. For 2–3 guests from 65 €/night.'
 type: doppelzimmer
 category: 'Doppelzimmer'
 shortDescription: >-

--- a/content/rooms/balkonzimmer.yml
+++ b/content/rooms/balkonzimmer.yml
@@ -1,5 +1,7 @@
 name: 'Balkonzimmer'
 slug: balkonzimmer
+seoTitle: 'Balkonzimmer mit Innenhofblick | Pension Volgenandt'
+seoDescription: 'Zweibettzimmer mit eigenem Balkon in Breitenbach, Eichsfeld. Für Paare & Alleinreisende. Ab 60 €/Nacht inkl. Frühstück.'
 type: zweibettzimmer
 category: 'Doppelzimmer'
 shortDescription: >-

--- a/content/rooms/einzelzimmer.yml
+++ b/content/rooms/einzelzimmer.yml
@@ -1,5 +1,7 @@
 name: 'Einzelzimmer'
 slug: einzelzimmer
+seoTitle: 'Einzelzimmer Leinefelde | Pension Volgenandt'
+seoDescription: 'Komfortables Einzelzimmer für Geschäftsreisende & Alleinreisende in Breitenbach, Eichsfeld. Ab 50 €/Nacht.'
 type: einzelzimmer
 category: 'Einzelzimmer'
 shortDescription: >-

--- a/content/rooms/emils-kuhwiese.yml
+++ b/content/rooms/emils-kuhwiese.yml
@@ -1,5 +1,7 @@
 name: "Ferienwohnung Emil's Kuhwiese"
 slug: emils-kuhwiese
+seoTitle: "Ferienwohnung Emil's Kuhwiese | Pension Volgenandt"
+seoDescription: 'Gemütliche Ferienwohnung mit Küche & Terrasse in Breitenbach, Eichsfeld. Ideal für 2–3 Gäste. Ab 73 €/Nacht.'
 type: ferienwohnung
 category: 'Ferienwohnung'
 shortDescription: >-

--- a/content/rooms/rosengarten.yml
+++ b/content/rooms/rosengarten.yml
@@ -1,5 +1,7 @@
 name: 'Rosengarten'
 slug: rosengarten
+seoTitle: 'Zimmer Rosengarten | Pension Volgenandt Eichsfeld'
+seoDescription: 'Charmantes Zweibettzimmer mit Blick auf den Rosengarten. Gemütlich eingerichtet, ideal für 2 Gäste. Ab 60 €/Nacht.'
 type: zweibettzimmer
 category: 'Doppelzimmer'
 shortDescription: >-

--- a/content/rooms/schoene-aussicht.yml
+++ b/content/rooms/schoene-aussicht.yml
@@ -1,5 +1,7 @@
 name: 'Ferienwohnung Schöne Aussicht'
 slug: schoene-aussicht
+seoTitle: 'Ferienwohnung Schöne Aussicht | Pension Volgenandt'
+seoDescription: 'Großzügige Ferienwohnung mit Panoramablick im Eichsfeld. 2 Schlafzimmer, Küche, bis 6 Gäste. Ab 126 €/Nacht.'
 type: ferienwohnung
 category: 'Ferienwohnung'
 shortDescription: >-

--- a/content/rooms/wohlfuehl-appartement.yml
+++ b/content/rooms/wohlfuehl-appartement.yml
@@ -1,5 +1,7 @@
 name: 'Wohlfühl-Appartement'
 slug: wohlfuehl-appartement
+seoTitle: 'Wohlfühl-Appartement | Pension Volgenandt Eichsfeld'
+seoDescription: 'Geräumiges Zimmer mit Kühlschrank, Wasserkocher & Schlafsofa in Breitenbach. Für 2–3 Gäste ab 65 €/Nacht.'
 type: doppelzimmer
 category: 'Doppelzimmer'
 shortDescription: >-

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -144,6 +144,9 @@ export default defineNuxtConfig({
         // Phase 4 activity pages
         '/aktivitaeten/wandern/',
         '/aktivitaeten/radfahren/',
+        // SEO landing pages
+        '/ferienwohnungen/',
+        '/monteurzimmer/',
         // News pages
         '/aktuelles/',
         '/aktuelles/landesgartenschau-2026/',
@@ -183,6 +186,9 @@ export default defineNuxtConfig({
         '/en/news/open-air-burg-scharfenstein-2026/',
         '/en/news/neuer-radweg-unstrut-leine/',
         '/en/news/baerenpark-festival-2026/',
+        // English SEO landing pages
+        '/en/holiday-apartments/',
+        '/en/worker-rooms/',
         // English legal pages
         '/en/imprint/',
         '/en/privacy/',


### PR DESCRIPTION
## Summary

- **LGS Countdown-Banner** auf Homepage-Hero (Desktop: Frosted-Glass-Overlay, Mobile: Inline-Karte mit Countdown)
- **LGS-Seite erweitert** mit Zimmerkarten, Booking-CTAs und Event-Schema.org-Markup
- **Neue Landingpages:** `/ferienwohnungen/` + `/monteurzimmer/` (DE+EN) mit LodgingBusiness-Schema
- **Room SEO:** seoTitle/seoDescription für alle 12 Zimmer-YAMLs + Schema-Update + Detail-Seiten
- **Activity SEO:** Verbesserte Titel für Wandern/Radfahren-Seiten ("Unterkunft"-Keywords)
- **hreflang-Fixes:** Fehlende EN + x-default Alternates auf deutschen Aktivitäts-, Ausflugsziel- und News-Detailseiten
- **Prettier:** Alle bestehenden Formatierungsprobleme behoben

## Context

Basierend auf `.planning/SEO-COMPETITIVE-ANALYSIS-2026-03.md`. Die Landesgartenschau 2026 öffnet am 23. April (25 Tage) — 325.000 Besucher erwartet. Kein lokaler Wettbewerber hat diese Seiten optimiert.

## Test plan

- [ ] Desktop: Frosted-Glass-Banner unten rechts im Hero sichtbar, Link funktioniert
- [ ] Mobile: Inline-Banner zwischen Hero und Welcome-Sektion, Link funktioniert
- [ ] Banner zeigt Countdown "Noch X Tage", wechselt zu "Jetzt erleben!" während Event
- [ ] `/ferienwohnungen/` zeigt nur Ferienwohnungen (Emil's + Schöne Aussicht)
- [ ] `/monteurzimmer/` zeigt alle Zimmer
- [ ] `/aktuelles/landesgartenschau-2026/` zeigt Zimmerkarten-Grid + Booking-CTA
- [ ] Zimmer-Detailseiten zeigen optimierte seoTitle in `<title>` Tag
- [ ] `npx nuxi generate` läuft fehlerfrei
- [ ] hreflang-Tags auf deutschen Seiten zeigen EN + x-default

🤖 Generated with [Claude Code](https://claude.com/claude-code)