### PR TITLE
fix: sync package.json with lockfile and harden weekly stats CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/monthly-stats.yml
+++ b/.github/workflows/monthly-stats.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/weekly-stats.yml
+++ b/.github/workflows/weekly-stats.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -12,23 +12,23 @@
   "dependencies": {
     "@fontsource-variable/dm-sans": "^5.2.8",
     "@fontsource-variable/lora": "^5.2.8",
-    "@nuxt/content": "^3.12.0",
+    "@nuxt/content": "^3.13.0",
     "@nuxt/eslint": "^1.15.2",
     "@nuxt/fonts": "^0.14.0",
     "@nuxt/icon": "^2.2.1",
     "@nuxt/image": "^2.0.0",
     "@nuxtjs/leaflet": "^1.3.2",
     "@nuxtjs/seo": "^3.4.0",
-    "@vueuse/integrations": "^14.2.1",
-    "@vueuse/nuxt": "^14.2.1",
-    "better-sqlite3": "^12.6.2",
+    "@vueuse/integrations": "^14.3.0",
+    "@vueuse/nuxt": "^14.3.0",
+    "better-sqlite3": "^12.9.0",
     "embla-carousel-accessibility": "9.0.0-rc01",
     "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-vue": "^8.6.0",
-    "focus-trap": "^8.0.0",
-    "nuxt": "^4.3.1",
-    "playwright": "^1.58.2",
-    "vue": "^3.5.30",
+    "focus-trap": "^8.1.0",
+    "nuxt": "^4.4.4",
+    "playwright": "^1.59.1",
+    "vue": "^3.5.33",
     "vue-router": "^4.6.4"
   },
   "pnpm": {
@@ -53,18 +53,18 @@
     }
   },
   "devDependencies": {
-    "@iconify-json/lucide": "^1.2.96",
+    "@iconify-json/lucide": "^1.2.105",
     "@iconify-json/ph": "^1.2.2",
     "@oxc-minify/binding-win32-x64-msvc": "0.112.0",
     "@oxc-parser/binding-win32-x64-msvc": "^0.112.0",
     "@oxc-transform/binding-win32-x64-msvc": "^0.112.0",
-    "@tailwindcss/vite": "^4.2.1",
+    "@tailwindcss/vite": "^4.2.4",
     "googleapis": "^171.4.0",
-    "nodemailer": "^8.0.4",
-    "prettier": "^3.8.1",
-    "prettier-plugin-tailwindcss": "^0.7.2",
-    "tailwindcss": "^4.2.1",
+    "nodemailer": "^8.0.7",
+    "prettier": "^3.8.3",
+    "prettier-plugin-tailwindcss": "^0.7.4",
+    "tailwindcss": "^4.2.4",
     "typescript": "^5.9.3",
-    "vue-tsc": "^3.2.5"
+    "vue-tsc": "^3.2.7"
   }
 }

--- a/scripts/weekly-stats.mjs
+++ b/scripts/weekly-stats.mjs
@@ -355,10 +355,21 @@ async function main() {
 
   const [bookings, nextArrivals, ga4] = await Promise.all([
     token
-      ? getNewBookings(token, weekStart, weekEnd)
+      ? getNewBookings(token, weekStart, weekEnd).catch((e) => {
+          console.error('Beds24 new bookings error:', e.message)
+          return { confirmed: 0, revenue: 0, byChannel: {} }
+        })
       : Promise.resolve({ confirmed: 0, revenue: 0, byChannel: {} }),
-    token ? getArrivals(token, nextWeekStart, nextWeekEnd) : Promise.resolve(0),
-    getGA4Data(),
+    token
+      ? getArrivals(token, nextWeekStart, nextWeekEnd).catch((e) => {
+          console.error('Beds24 arrivals error:', e.message)
+          return 0
+        })
+      : Promise.resolve(0),
+    getGA4Data().catch((e) => {
+      console.error('GA4 error:', e.message)
+      return null
+    }),
   ])
 
   console.log(`New bookings: ${bookings.confirmed} (€${bookings.revenue.toFixed(0)})`)
@@ -370,11 +381,17 @@ async function main() {
 
   const html = buildEmail({ bookings, nextArrivals, ga4 })
 
+  if (!SMTP_USER || !SMTP_PASS) {
+    console.warn('SMTP credentials not set, skipping email send')
+    return
+  }
+
   const transporter = createTransport({
     host: SMTP_HOST,
     port: parseInt(SMTP_PORT),
     secure: false,
     auth: { user: SMTP_USER, pass: SMTP_PASS },
+    tls: { rejectUnauthorized: false },
   })
 
   const recipients = REPORT_RECIPIENTS.split(',').map((s) => s.trim())


### PR DESCRIPTION
## Summary

- **Root cause of Friday CI failure**: pnpm-lock.yaml had newer version specifiers than package.json, causing pnpm install to fail with ERR_PNPM_OUTDATED_LOCKFILE in frozen-lockfile mode — the weekly stats script never even ran
- Upgrade all three workflows from Node.js 20 to 24 ahead of the GitHub-enforced June 2nd deadline
- Harden weekly-stats.mjs error handling to match the monthly stats pattern

## Changes

- `package.json`: sync version specifiers to match lockfile (nodemailer, nuxt, tailwindcss, etc.)
- `.github/workflows/*.yml`: Node.js 20 to 24 in deploy, monthly-stats, weekly-stats
- `scripts/weekly-stats.mjs`: add .catch() on each Promise.all entry, add tls.rejectUnauthorized:false and SMTP credential guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)