### PR TITLE
feat: GA4 conversion tracking + SEO for Picknick

### DIFF
--- a/app/components/picknick/BookingForm.vue
+++ b/app/components/picknick/BookingForm.vue
@@ -2,6 +2,7 @@
 const appConfig = useAppConfig()
 const router = useRouter()
 const { isReady: paypalReady } = usePayPal()
+const { trackEvent } = useAnalytics()
 
 const KIDS_PRICE = 9.5
 const EXTRA_DRINK_PRICE = 3
@@ -154,6 +155,24 @@ watch(
   () => form.packageId,
   () => {
     form.drinks = {}
+    const pkg = packages.value.find((p) => p.id === form.packageId)
+    if (pkg) {
+      trackEvent('view_item', {
+        items: [{ item_name: pkg.name, price: pkg.price }],
+        currency: 'EUR',
+      })
+    }
+  },
+)
+
+const leadTracked = ref(false)
+watch(
+  () => form.name,
+  (val) => {
+    if (val && !leadTracked.value) {
+      leadTracked.value = true
+      trackEvent('generate_lead')
+    }
   },
 )
 
@@ -289,6 +308,11 @@ function renderPayPalButton() {
             'Bitte füllen Sie alle Pflichtfelder aus und wählen Sie die Getränke.'
           return Promise.reject(new Error('Form invalid'))
         }
+        trackEvent('begin_checkout', {
+          value: grandTotal.value,
+          currency: 'EUR',
+          items: [{ item_name: selectedPackage.value?.name, quantity: totalPersons.value }],
+        })
         return actions.order.create({
           purchase_units: [
             {
@@ -324,6 +348,18 @@ function renderPayPalButton() {
           const result = await response.json()
 
           if (response.ok && result.ok) {
+            trackEvent('purchase', {
+              transaction_id: result.transactionId ?? data.orderID,
+              value: grandTotal.value,
+              currency: 'EUR',
+              items: [
+                {
+                  item_name: selectedPackage.value?.name ?? '',
+                  quantity: totalPersons.value,
+                  price: grandTotal.value,
+                },
+              ],
+            })
             await router.push({
               path: '/picknick/danke/',
               query: {

--- a/app/pages/picknick/index.vue
+++ b/app/pages/picknick/index.vue
@@ -4,7 +4,7 @@ definePageMeta({
 })
 
 useSeoMeta({
-  title: 'Picknick-Korb – Genießer Frühstück to go',
+  title: 'Picknick-Korb ab 19 € | Pension Volgenandt Eichsfeld',
   ogTitle: 'Picknick-Korb | Pension Volgenandt',
   description:
     'Hausgemacht, regional, mit Herz gepackt. Buchen Sie Ihren Picknick-Korb für den Garten oder die Umgebung – ab 19 € pro Person.',
@@ -23,6 +23,30 @@ useHead({
       rel: 'alternate',
       hreflang: 'x-default',
       href: 'https://www.pension-volgenandt.de/picknick/',
+    },
+  ],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Product',
+        name: 'Picknick-Korb',
+        description:
+          'Hausgemachter Picknick-Korb mit regionalen Produkten, Picknickdecke, Geschirr und Besteck. Verschiedene Pakete ab 19 € pro Person.',
+        offers: {
+          '@type': 'Offer',
+          price: '19.00',
+          priceCurrency: 'EUR',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.pension-volgenandt.de/picknick/',
+        },
+        provider: {
+          '@type': 'BedAndBreakfast',
+          name: 'Pension Volgenandt',
+          url: 'https://www.pension-volgenandt.de',
+        },
+      }),
     },
   ],
 })


### PR DESCRIPTION
## Summary

- **BookingForm.vue**: adds `view_item`, `generate_lead`, `begin_checkout` and `purchase` GA4 events — gives Google Ads Smart Bidding real purchase signal with transaction value
- **picknick/index.vue**: meta title updated to include price (`ab 19 €`) for better CTR; JSON-LD `Product` schema added for rich results

## Google Ads changes (done separately via Playwright)
- `purchase` conversion action imported from GA4 (Kauf category, dynamic value)
- Remarketing audience "Picknick-Seitenbesucher" (URL contains `/picknick/`)
- Remarketing audience "Picknick-Buchung abgebrochen" (visited buchen, excluded danke)
- Account-level Final URL suffix: `utm_source=google&utm_medium=cpc&utm_campaign={campaign}&utm_content={adgroup}`

## Test plan
- [ ] Deploy and open `/picknick/buchen/` — switch package, check GA4 Realtime for `view_item`
- [ ] Fill name field — check GA4 Realtime for `generate_lead`
- [ ] Click PayPal button — check GA4 Realtime for `begin_checkout`
- [ ] Complete a test payment — check GA4 Realtime for `purchase` with correct value
- [ ] Check Google Ads Conversions in ~24h for first `purchase` conversion data

🤖 Generated with [Claude Code](https://claude.com/claude-code)