### PR TITLE
fix(seo): structured data cleanup + legacy 404 redirects (Google Search Console)

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useJsonLd } from '~/composables/useJsonLd'
+
 const baseURL = useRuntimeConfig().app.baseURL
 
 useHead({
@@ -20,60 +22,63 @@ useSeoMeta({
   ogSiteName: 'Pension Volgenandt',
 })
 
-useSchemaOrg([
-  {
-    '@type': 'WebSite',
-    name: 'Pension Volgenandt',
-    url: 'https://www.pension-volgenandt.de',
-    inLanguage: 'de-DE',
-  },
-  {
-    '@type': 'BedAndBreakfast',
-    '@id': 'https://www.pension-volgenandt.de/#identity',
-    name: 'Pension Volgenandt',
-    description:
-      'Familiär geführte Pension in Breitenbach, Eichsfeld. Ferienwohnungen und Zimmer mit Blick ins Grüne.',
-    url: 'https://www.pension-volgenandt.de',
-    logo: 'https://www.pension-volgenandt.de/favicon.svg',
-    image: 'https://www.pension-volgenandt.de/img/hero/hero-poster.webp',
-    telephone: '+49 160 97719112',
-    email: 'kontakt@pension-volgenandt.de',
-    address: {
-      '@type': 'PostalAddress',
-      streetAddress: 'Otto-Reutter-Straße 28',
-      addressLocality: 'Leinefelde-Worbis OT Breitenbach',
-      postalCode: '37327',
-      addressRegion: 'Thüringen',
-      addressCountry: 'DE',
+useJsonLd(
+  [
+    {
+      '@type': 'WebSite',
+      name: 'Pension Volgenandt',
+      url: 'https://www.pension-volgenandt.de',
+      inLanguage: 'de-DE',
     },
-    geo: {
-      '@type': 'GeoCoordinates',
-      latitude: 51.4124,
-      longitude: 10.322,
-    },
-    amenityFeature: [
-      { '@type': 'LocationFeatureSpecification', name: 'WiFi', value: true },
-      { '@type': 'LocationFeatureSpecification', name: 'Parking', value: true },
-      { '@type': 'LocationFeatureSpecification', name: 'Breakfast', value: true },
-    ],
-    petsAllowed: true,
-    priceRange: 'EUR 38-89',
-    checkinTime: '14:00',
-    checkoutTime: '11:00',
-    openingHoursSpecification: [
-      {
-        '@type': 'OpeningHoursSpecification',
-        dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
-        opens: '08:00',
-        closes: '22:00',
+    {
+      '@type': 'BedAndBreakfast',
+      '@id': 'https://www.pension-volgenandt.de/#identity',
+      name: 'Pension Volgenandt',
+      description:
+        'Familiär geführte Pension in Breitenbach, Eichsfeld. Ferienwohnungen und Zimmer mit Blick ins Grüne.',
+      url: 'https://www.pension-volgenandt.de',
+      logo: 'https://www.pension-volgenandt.de/favicon.svg',
+      image: 'https://www.pension-volgenandt.de/img/hero/hero-poster.webp',
+      telephone: '+49 160 97719112',
+      email: 'kontakt@pension-volgenandt.de',
+      address: {
+        '@type': 'PostalAddress',
+        streetAddress: 'Otto-Reutter-Straße 28',
+        addressLocality: 'Leinefelde-Worbis OT Breitenbach',
+        postalCode: '37327',
+        addressRegion: 'Thüringen',
+        addressCountry: 'DE',
       },
-    ],
-    sameAs: [
-      'https://maps.app.goo.gl/pGocG9jFPzXkpvGbA',
-      'https://www.booking.com/hotel/de/pension-volgenandt.de.html',
-    ],
-  },
-])
+      geo: {
+        '@type': 'GeoCoordinates',
+        latitude: 51.4124,
+        longitude: 10.322,
+      },
+      amenityFeature: [
+        { '@type': 'LocationFeatureSpecification', name: 'WiFi', value: true },
+        { '@type': 'LocationFeatureSpecification', name: 'Parking', value: true },
+        { '@type': 'LocationFeatureSpecification', name: 'Breakfast', value: true },
+      ],
+      petsAllowed: true,
+      priceRange: 'EUR 38-89',
+      checkinTime: '14:00',
+      checkoutTime: '11:00',
+      openingHoursSpecification: [
+        {
+          '@type': 'OpeningHoursSpecification',
+          dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'],
+          opens: '08:00',
+          closes: '22:00',
+        },
+      ],
+      sameAs: [
+        'https://maps.app.goo.gl/pGocG9jFPzXkpvGbA',
+        'https://www.booking.com/hotel/de/pension-volgenandt.de.html',
+      ],
+    },
+  ],
+  'global-structured-data',
+)
 </script>
 
 <template>

--- a/app/composables/useJsonLd.ts
+++ b/app/composables/useJsonLd.ts
@@ -1,0 +1,23 @@
+type JsonLdNode = Record<string, unknown>
+
+function isJsonLdGraph(value: unknown): value is JsonLdNode {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+export function useJsonLd(input: JsonLdNode | JsonLdNode[], key = 'json-ld') {
+  const payload = Array.isArray(input)
+    ? { '@context': 'https://schema.org', '@graph': input }
+    : isJsonLdGraph(input) && input['@context']
+      ? input
+      : { '@context': 'https://schema.org', ...input }
+
+  useHead({
+    script: [
+      {
+        key,
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(payload),
+      },
+    ],
+  })
+}

--- a/app/composables/useLocale.ts
+++ b/app/composables/useLocale.ts
@@ -24,12 +24,16 @@ const enToDe: Record<string, string> = Object.fromEntries(
 // German paths that have English counterparts
 const translatedDePaths = Object.keys(deToEn)
 
-// Special sub-route mappings (DE slug → EN slug)
+// Special page mappings (DE slug → EN slug) for standalone pages whose slugs
+// don't share a common base prefix. Covers sub-routes plus top-level page pairs
+// like Über uns/About and the booking thank-you pages.
 const subRouteMappings: Record<string, string> = {
   '/aktivitaeten/wandern': '/activities/hiking',
   '/aktivitaeten/radfahren': '/activities/cycling',
   '/picknick/buchen': '/picnic/book',
   '/picknick/danke': '/picnic/thanks',
+  '/willkommen': '/about',
+  '/buchung-danke': '/booking-thank-you',
 }
 
 const subRouteMappingsReverse: Record<string, string> = Object.fromEntries(

--- a/app/pages/aktuelles/[slug].vue
+++ b/app/pages/aktuelles/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const { locale } = useLocale()
 const route = useRoute()
@@ -58,13 +59,19 @@ useHead({
 const schemaItems: Record<string, unknown>[] = [
   {
     '@type': 'NewsArticle',
+    '@id': `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/#article`,
     headline: article.value.seoTitle,
+    url: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
+    mainEntityOfPage: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
     description: article.value.seoDescription,
-    image: `https://www.pension-volgenandt.de${article.value.heroImage}`,
+    image: [`https://www.pension-volgenandt.de${article.value.heroImage}`],
     datePublished: article.value.publishedDate,
     author: {
       '@type': 'Organization',
       name: 'Pension Volgenandt',
+    },
+    publisher: {
+      '@id': 'https://www.pension-volgenandt.de/#identity',
     },
   },
 ]
@@ -73,7 +80,11 @@ const schemaItems: Record<string, unknown>[] = [
 if (article.value.eventStartDate && article.value.eventEndDate) {
   schemaItems.push({
     '@type': 'Event',
+    '@id': `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/#event`,
     name: article.value.title,
+    url: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
+    description: article.value.seoDescription,
+    image: [`https://www.pension-volgenandt.de${article.value.heroImage}`],
     startDate: article.value.eventStartDate,
     endDate: article.value.eventEndDate,
     eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
@@ -93,18 +104,10 @@ if (article.value.eventStartDate && article.value.eventEndDate) {
       name: 'Landesgartenschau Leinefelde-Worbis 2026 gGmbH',
       url: 'https://www.lgs-leinefelde-worbis.de/',
     },
-    offers: {
-      '@type': 'Offer',
-      name: t('lgs.pageTitle', locale.value),
-      url: `https://www.pension-volgenandt.de/aktuelles/${article.value.slug}/`,
-      priceCurrency: 'EUR',
-      price: '50',
-      availability: 'https://schema.org/InStock',
-    },
   })
 }
 
-useSchemaOrg(schemaItems)
+useJsonLd(schemaItems, `news-schema-de-${slug}`)
 
 definePageMeta({
   breadcrumb: { label: 'Artikel' },

--- a/app/pages/ausflugsziele/[slug].vue
+++ b/app/pages/ausflugsziele/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const { locale } = useLocale()
 const route = useRoute()
@@ -51,16 +52,18 @@ useHead({
 })
 
 // TouristAttraction structured data
-useSchemaOrg([
+useJsonLd(
   {
     '@type': 'TouristAttraction',
+    '@id': `https://www.pension-volgenandt.de/ausflugsziele/${attraction.value.slug}/#attraction`,
     name: attraction.value.name,
     description: attraction.value.seoDescription,
-    image: `https://www.pension-volgenandt.de${attraction.value.heroImage}`,
+    image: [`https://www.pension-volgenandt.de${attraction.value.heroImage}`],
     url: `https://www.pension-volgenandt.de/ausflugsziele/${attraction.value.slug}/`,
     ...(attraction.value.website ? { sameAs: attraction.value.website } : {}),
   },
-])
+  `attraction-schema-de-${slug}`,
+)
 
 // Breadcrumb with dynamic label
 definePageMeta({

--- a/app/pages/en/about.vue
+++ b/app/pages/en/about.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 useHead({
   htmlAttrs: { lang: 'en' },
@@ -26,31 +27,39 @@ useSeoMeta({
   ogType: 'profile',
 })
 
-useSchemaOrg([
-  defineWebPage({
-    '@type': 'AboutPage',
-  }),
-  {
-    '@type': 'Person',
-    name: 'Simone Volgenandt',
-    jobTitle: 'Host',
-    worksFor: {
-      '@id': 'https://www.pension-volgenandt.de/#identity',
+useJsonLd(
+  [
+    {
+      '@type': 'AboutPage',
+      '@id': 'https://www.pension-volgenandt.de/en/about/#about-page',
+      url: 'https://www.pension-volgenandt.de/en/about/',
+      name: 'About Us – Simone & Ralf Volgenandt',
+      description:
+        'Meet your hosts: Simone & Ralf Volgenandt run their guesthouse in Breitenbach with warmth and a love of nature.',
     },
-    url: 'https://www.pension-volgenandt.de/en/about/',
-    image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
-  },
-  {
-    '@type': 'Person',
-    name: 'Ralf Volgenandt',
-    jobTitle: 'Host',
-    worksFor: {
-      '@id': 'https://www.pension-volgenandt.de/#identity',
+    {
+      '@type': 'Person',
+      name: 'Simone Volgenandt',
+      jobTitle: 'Host',
+      worksFor: {
+        '@id': 'https://www.pension-volgenandt.de/#identity',
+      },
+      url: 'https://www.pension-volgenandt.de/en/about/',
+      image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
     },
-    url: 'https://www.pension-volgenandt.de/en/about/',
-    image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
-  },
-])
+    {
+      '@type': 'Person',
+      name: 'Ralf Volgenandt',
+      jobTitle: 'Host',
+      worksFor: {
+        '@id': 'https://www.pension-volgenandt.de/#identity',
+      },
+      url: 'https://www.pension-volgenandt.de/en/about/',
+      image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
+    },
+  ],
+  'about-schema-en',
+)
 </script>
 
 <template>

--- a/app/pages/en/attractions/[slug].vue
+++ b/app/pages/en/attractions/[slug].vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useJsonLd } from '~/composables/useJsonLd'
+
 const route = useRoute()
 const slug = route.params.slug as string
 
@@ -49,16 +51,18 @@ useHead({
 })
 
 // TouristAttraction structured data
-useSchemaOrg([
+useJsonLd(
   {
     '@type': 'TouristAttraction',
+    '@id': `https://www.pension-volgenandt.de/en/attractions/${attraction.value.slug}/#attraction`,
     name: attraction.value.name,
     description: attraction.value.seoDescription,
-    image: `https://www.pension-volgenandt.de${attraction.value.heroImage}`,
+    image: [`https://www.pension-volgenandt.de${attraction.value.heroImage}`],
     url: `https://www.pension-volgenandt.de/en/attractions/${attraction.value.slug}/`,
     ...(attraction.value.website ? { sameAs: attraction.value.website } : {}),
   },
-])
+  `attraction-schema-en-${slug}`,
+)
 
 // Breadcrumb with dynamic label
 definePageMeta({

--- a/app/pages/en/contact.vue
+++ b/app/pages/en/contact.vue
@@ -1,22 +1,28 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const siteUrl = 'https://www.pension-volgenandt.de'
 
 const { data: faqData } = await useAsyncData('faq-en', () => queryCollection('faqEn').first())
 const faqItems = computed(() => faqData.value?.items ?? [])
 
-useSchemaOrg([
-  defineWebPage({
+useJsonLd(
+  {
     '@type': 'FAQPage',
-  }),
-  ...(faqData.value?.items ?? []).map((item) =>
-    defineQuestion({
+    '@id': `${siteUrl}/en/contact/#faq`,
+    url: `${siteUrl}/en/contact/`,
+    mainEntity: (faqData.value?.items ?? []).map((item) => ({
+      '@type': 'Question',
       name: item.question,
-      acceptedAnswer: item.answer.replace(/<[^>]*>/g, ''),
-    }),
-  ),
-])
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer.replace(/<[^>]*>/g, ''),
+      },
+    })),
+  },
+  'contact-faq-schema-en',
+)
 
 useHead({
   htmlAttrs: { lang: 'en' },

--- a/app/pages/en/holiday-apartments.vue
+++ b/app/pages/en/holiday-apartments.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const siteUrl = 'https://www.pension-volgenandt.de'
 
@@ -25,23 +26,29 @@ useHead({
   ],
 })
 
-useSchemaOrg([
+useJsonLd(
   {
     '@type': 'LodgingBusiness',
+    '@id': `${siteUrl}/en/holiday-apartments/#lodging`,
     name: 'Pension Volgenandt – Holiday Apartments',
     description:
       'Holiday apartments in the Eichsfeld region near Leinefelde-Worbis with kitchen, terrace, and 25,000 m² garden.',
     url: `${siteUrl}/en/holiday-apartments/`,
+    image: [`${siteUrl}/img/rooms/schoene-aussicht-wohnkueche.webp`],
+    containedInPlace: {
+      '@id': `${siteUrl}/#identity`,
+    },
     address: {
       '@type': 'PostalAddress',
-      streetAddress: 'Breitenbach 12',
-      addressLocality: 'Leinefelde-Worbis',
+      streetAddress: 'Otto-Reutter-Straße 28',
+      addressLocality: 'Leinefelde-Worbis OT Breitenbach',
       postalCode: '37327',
       addressRegion: 'Thuringia',
       addressCountry: 'DE',
     },
   },
-])
+  'holiday-apartments-schema-en',
+)
 
 const { data: rooms } = await useAsyncData('ferienwohnungen-en', () =>
   queryCollection('roomsEn').where('type', '=', 'ferienwohnung').order('sortOrder', 'ASC').all(),

--- a/app/pages/en/news/[slug].vue
+++ b/app/pages/en/news/[slug].vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const route = useRoute()
 const slug = route.params.slug as string
@@ -58,13 +59,19 @@ useHead({
 const schemaItems: Record<string, unknown>[] = [
   {
     '@type': 'NewsArticle',
+    '@id': `https://www.pension-volgenandt.de/en/news/${article.value.slug}/#article`,
     headline: article.value.seoTitle,
+    url: `https://www.pension-volgenandt.de/en/news/${article.value.slug}/`,
+    mainEntityOfPage: `https://www.pension-volgenandt.de/en/news/${article.value.slug}/`,
     description: article.value.seoDescription,
-    image: `https://www.pension-volgenandt.de${article.value.heroImage}`,
+    image: [`https://www.pension-volgenandt.de${article.value.heroImage}`],
     datePublished: article.value.publishedDate,
     author: {
       '@type': 'Organization',
       name: 'Pension Volgenandt',
+    },
+    publisher: {
+      '@id': 'https://www.pension-volgenandt.de/#identity',
     },
   },
 ]
@@ -73,7 +80,11 @@ const schemaItems: Record<string, unknown>[] = [
 if (article.value.eventStartDate && article.value.eventEndDate) {
   schemaItems.push({
     '@type': 'Event',
+    '@id': `https://www.pension-volgenandt.de/en/news/${article.value.slug}/#event`,
     name: article.value.title,
+    url: `https://www.pension-volgenandt.de/en/news/${article.value.slug}/`,
+    description: article.value.seoDescription,
+    image: [`https://www.pension-volgenandt.de${article.value.heroImage}`],
     startDate: article.value.eventStartDate,
     endDate: article.value.eventEndDate,
     eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
@@ -93,18 +104,10 @@ if (article.value.eventStartDate && article.value.eventEndDate) {
       name: 'Landesgartenschau Leinefelde-Worbis 2026 gGmbH',
       url: 'https://www.lgs-leinefelde-worbis.de/',
     },
-    offers: {
-      '@type': 'Offer',
-      name: 'Accommodation for the State Garden Show 2026',
-      url: `https://www.pension-volgenandt.de/en/news/${article.value.slug}/`,
-      priceCurrency: 'EUR',
-      price: '50',
-      availability: 'https://schema.org/InStock',
-    },
   })
 }
 
-useSchemaOrg(schemaItems)
+useJsonLd(schemaItems, `news-schema-en-${slug}`)
 
 definePageMeta({
   breadcrumb: { label: 'Article' },

--- a/app/pages/en/picnic/index.vue
+++ b/app/pages/en/picnic/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useJsonLd } from '~/composables/useJsonLd'
+
 const siteUrl = 'https://www.pension-volgenandt.de'
 
 definePageMeta({
@@ -25,6 +27,35 @@ useSeoMeta({
   ogImage: '/img/picknick/header-picknick.webp',
   ogType: 'website',
 })
+
+useJsonLd(
+  {
+    '@type': 'Product',
+    '@id': `${siteUrl}/en/picnic/#product`,
+    name: 'Picnic Basket',
+    url: `${siteUrl}/en/picnic/`,
+    image: [`${siteUrl}/img/picknick/header-picknick.webp`],
+    description:
+      'Homemade picnic basket with regional products, picnic blanket, dishes and cutlery. Several packages from 19 EUR per person.',
+    brand: {
+      '@type': 'Brand',
+      name: 'Pension Volgenandt',
+    },
+    category: 'Picnic basket',
+    offers: {
+      '@type': 'Offer',
+      price: '19.00',
+      priceCurrency: 'EUR',
+      availability: 'https://schema.org/InStock',
+      itemCondition: 'https://schema.org/NewCondition',
+      url: `${siteUrl}/en/picnic/`,
+      seller: {
+        '@id': 'https://www.pension-volgenandt.de/#identity',
+      },
+    },
+  },
+  'picnic-product-schema-en',
+)
 
 const { data: packagesData } = await useAsyncData('picknick-packages', () =>
   queryCollection('picknickPackages').first(),

--- a/app/pages/en/rooms/[slug].vue
+++ b/app/pages/en/rooms/[slug].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
 import { getAmenityLabel } from '~/utils/amenities'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const route = useRoute()
 const slug = route.params.slug as string
@@ -89,12 +90,17 @@ useSeoMeta({
 })
 
 // HotelRoom + Offer Schema.org structured data (English)
-useSchemaOrg([
+useJsonLd(
   {
-    '@type': ['HotelRoom', 'Product'],
+    '@type': 'HotelRoom',
+    '@id': `${siteUrl}/en/rooms/${room.value.slug}/#room`,
     name: room.value.name,
+    url: `${siteUrl}/en/rooms/${room.value.slug}/`,
     description: room.value.shortDescription,
-    image: `${siteUrl}${room.value.heroImage}`,
+    image: [`${siteUrl}${room.value.heroImage}`],
+    containedInPlace: {
+      '@id': `${siteUrl}/#identity`,
+    },
     occupancy: {
       '@type': 'QuantitativeValue',
       maxValue: room.value.maxGuests,
@@ -113,12 +119,10 @@ useSchemaOrg([
         period.rates.map((rate) => ({
           '@type': 'Offer',
           name: `${room.value!.name} - ${period.label}`,
-          priceSpecification: {
-            '@type': 'UnitPriceSpecification',
-            price: rate.pricePerNight,
-            priceCurrency: 'EUR',
-            unitCode: 'DAY',
-          },
+          price: String(rate.pricePerNight),
+          priceCurrency: 'EUR',
+          availability: 'https://schema.org/InStock',
+          url: `${siteUrl}/en/rooms/${room.value!.slug}/`,
           businessFunction: 'http://purl.org/goodrelations/v1#LeaseOut',
           eligibleQuantity: {
             '@type': 'QuantitativeValue',
@@ -128,7 +132,8 @@ useSchemaOrg([
         })),
     ),
   },
-])
+  `room-schema-en-${slug}`,
+)
 </script>
 
 <template>

--- a/app/pages/en/worker-rooms.vue
+++ b/app/pages/en/worker-rooms.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const siteUrl = 'https://www.pension-volgenandt.de'
 
@@ -25,17 +26,22 @@ useHead({
   ],
 })
 
-useSchemaOrg([
+useJsonLd(
   {
     '@type': 'LodgingBusiness',
+    '@id': `${siteUrl}/en/worker-rooms/#lodging`,
     name: 'Pension Volgenandt – Worker Accommodation',
     description:
       'Worker and business rooms in Leinefelde-Worbis. Affordable, comfortable, with WiFi and parking.',
     url: `${siteUrl}/en/worker-rooms/`,
+    image: [`${siteUrl}/img/hero/hero-poster.webp`],
+    containedInPlace: {
+      '@id': `${siteUrl}/#identity`,
+    },
     address: {
       '@type': 'PostalAddress',
-      streetAddress: 'Breitenbach 12',
-      addressLocality: 'Leinefelde-Worbis',
+      streetAddress: 'Otto-Reutter-Straße 28',
+      addressLocality: 'Leinefelde-Worbis OT Breitenbach',
       postalCode: '37327',
       addressRegion: 'Thuringia',
       addressCountry: 'DE',
@@ -45,7 +51,8 @@ useSchemaOrg([
       audienceType: 'Business travelers',
     },
   },
-])
+  'worker-rooms-schema-en',
+)
 
 const { data: rooms } = await useAsyncData('monteurzimmer-en', () =>
   queryCollection('roomsEn').order('sortOrder', 'ASC').all(),

--- a/app/pages/ferienwohnungen.vue
+++ b/app/pages/ferienwohnungen.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const { locale } = useLocale()
 const siteUrl = 'https://www.pension-volgenandt.de'
@@ -25,23 +26,29 @@ useHead({
   ],
 })
 
-useSchemaOrg([
+useJsonLd(
   {
     '@type': 'LodgingBusiness',
+    '@id': `${siteUrl}/ferienwohnungen/#lodging`,
     name: 'Pension Volgenandt – Ferienwohnungen',
     description:
       'Ferienwohnungen im Eichsfeld bei Leinefelde-Worbis mit Küche, Terrasse und 25.000 m² Garten.',
     url: `${siteUrl}/ferienwohnungen/`,
+    image: [`${siteUrl}/img/rooms/schoene-aussicht-wohnkueche.webp`],
+    containedInPlace: {
+      '@id': `${siteUrl}/#identity`,
+    },
     address: {
       '@type': 'PostalAddress',
-      streetAddress: 'Breitenbach 12',
-      addressLocality: 'Leinefelde-Worbis',
+      streetAddress: 'Otto-Reutter-Straße 28',
+      addressLocality: 'Leinefelde-Worbis OT Breitenbach',
       postalCode: '37327',
       addressRegion: 'Thüringen',
       addressCountry: 'DE',
     },
   },
-])
+  'holiday-apartments-schema-de',
+)
 
 const { data: rooms } = await useAsyncData('ferienwohnungen', () =>
   queryCollection('rooms').where('type', '=', 'ferienwohnung').order('sortOrder', 'ASC').all(),

--- a/app/pages/kontakt.vue
+++ b/app/pages/kontakt.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const { locale } = useLocale()
 
@@ -49,17 +50,22 @@ const { data: faqData } = await useAsyncData('faq', () => queryCollection('faq')
 // FAQPage structured data
 const faqItems = computed(() => faqData.value?.items ?? [])
 
-useSchemaOrg([
-  defineWebPage({
+useJsonLd(
+  {
     '@type': 'FAQPage',
-  }),
-  ...(faqData.value?.items ?? []).map((item) =>
-    defineQuestion({
+    '@id': 'https://www.pension-volgenandt.de/kontakt/#faq',
+    url: 'https://www.pension-volgenandt.de/kontakt/',
+    mainEntity: (faqData.value?.items ?? []).map((item) => ({
+      '@type': 'Question',
       name: item.question,
-      acceptedAnswer: item.answer.replace(/<[^>]*>/g, ''),
-    }),
-  ),
-])
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer.replace(/<[^>]*>/g, ''),
+      },
+    })),
+  },
+  'contact-faq-schema-de',
+)
 </script>
 
 <template>

--- a/app/pages/monteurzimmer.vue
+++ b/app/pages/monteurzimmer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const { locale } = useLocale()
 const siteUrl = 'https://www.pension-volgenandt.de'
@@ -25,17 +26,22 @@ useHead({
   ],
 })
 
-useSchemaOrg([
+useJsonLd(
   {
     '@type': 'LodgingBusiness',
+    '@id': `${siteUrl}/monteurzimmer/#lodging`,
     name: 'Pension Volgenandt – Monteurzimmer',
     description:
       'Monteurzimmer und Firmenzimmer in Leinefelde-Worbis. Günstig, komfortabel, mit WLAN und Parkplatz.',
     url: `${siteUrl}/monteurzimmer/`,
+    image: [`${siteUrl}/img/hero/hero-poster.webp`],
+    containedInPlace: {
+      '@id': `${siteUrl}/#identity`,
+    },
     address: {
       '@type': 'PostalAddress',
-      streetAddress: 'Breitenbach 12',
-      addressLocality: 'Leinefelde-Worbis',
+      streetAddress: 'Otto-Reutter-Straße 28',
+      addressLocality: 'Leinefelde-Worbis OT Breitenbach',
       postalCode: '37327',
       addressRegion: 'Thüringen',
       addressCountry: 'DE',
@@ -45,7 +51,8 @@ useSchemaOrg([
       audienceType: 'Business travelers',
     },
   },
-])
+  'worker-rooms-schema-de',
+)
 
 const { data: rooms } = await useAsyncData('monteurzimmer', () =>
   queryCollection('rooms').order('sortOrder', 'ASC').all(),

--- a/app/pages/picknick/index.vue
+++ b/app/pages/picknick/index.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useJsonLd } from '~/composables/useJsonLd'
+
 definePageMeta({
   breadcrumb: { label: 'Picknick-Korb' },
 })
@@ -25,31 +27,36 @@ useHead({
       href: 'https://www.pension-volgenandt.de/picknick/',
     },
   ],
-  script: [
-    {
-      type: 'application/ld+json',
-      innerHTML: JSON.stringify({
-        '@context': 'https://schema.org',
-        '@type': 'Product',
-        name: 'Picknick-Korb',
-        description:
-          'Hausgemachter Picknick-Korb mit regionalen Produkten, Picknickdecke, Geschirr und Besteck. Verschiedene Pakete ab 19 € pro Person.',
-        offers: {
-          '@type': 'Offer',
-          price: '19.00',
-          priceCurrency: 'EUR',
-          availability: 'https://schema.org/InStock',
-          url: 'https://www.pension-volgenandt.de/picknick/',
-        },
-        provider: {
-          '@type': 'BedAndBreakfast',
-          name: 'Pension Volgenandt',
-          url: 'https://www.pension-volgenandt.de',
-        },
-      }),
-    },
-  ],
 })
+
+useJsonLd(
+  {
+    '@type': 'Product',
+    '@id': 'https://www.pension-volgenandt.de/picknick/#product',
+    name: 'Picknick-Korb',
+    url: 'https://www.pension-volgenandt.de/picknick/',
+    image: ['https://www.pension-volgenandt.de/img/picknick/header-picknick.webp'],
+    description:
+      'Hausgemachter Picknick-Korb mit regionalen Produkten, Picknickdecke, Geschirr und Besteck. Verschiedene Pakete ab 19 € pro Person.',
+    brand: {
+      '@type': 'Brand',
+      name: 'Pension Volgenandt',
+    },
+    category: 'Picnic basket',
+    offers: {
+      '@type': 'Offer',
+      price: '19.00',
+      priceCurrency: 'EUR',
+      availability: 'https://schema.org/InStock',
+      itemCondition: 'https://schema.org/NewCondition',
+      url: 'https://www.pension-volgenandt.de/picknick/',
+      seller: {
+        '@id': 'https://www.pension-volgenandt.de/#identity',
+      },
+    },
+  },
+  'picnic-product-schema-de',
+)
 
 const { data: packagesData } = await useAsyncData('picknick-packages', () =>
   queryCollection('picknickPackages').first(),

--- a/app/pages/willkommen.vue
+++ b/app/pages/willkommen.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 definePageMeta({
   breadcrumb: { label: 'Über uns' },
@@ -29,31 +30,39 @@ useHead({
   ],
 })
 
-useSchemaOrg([
-  defineWebPage({
-    '@type': 'AboutPage',
-  }),
-  {
-    '@type': 'Person',
-    name: 'Simone Volgenandt',
-    jobTitle: 'Gastgeberin',
-    worksFor: {
-      '@id': 'https://www.pension-volgenandt.de/#identity',
+useJsonLd(
+  [
+    {
+      '@type': 'AboutPage',
+      '@id': 'https://www.pension-volgenandt.de/willkommen/#about-page',
+      url: 'https://www.pension-volgenandt.de/willkommen/',
+      name: 'Über uns – Simone & Ralf Volgenandt',
+      description:
+        'Lernen Sie Ihre Gastgeber kennen: Simone & Ralf Volgenandt führen ihre Pension in Breitenbach mit Herzlichkeit und Liebe zur Natur.',
     },
-    url: 'https://www.pension-volgenandt.de/willkommen/',
-    image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
-  },
-  {
-    '@type': 'Person',
-    name: 'Ralf Volgenandt',
-    jobTitle: 'Gastgeber',
-    worksFor: {
-      '@id': 'https://www.pension-volgenandt.de/#identity',
+    {
+      '@type': 'Person',
+      name: 'Simone Volgenandt',
+      jobTitle: 'Gastgeberin',
+      worksFor: {
+        '@id': 'https://www.pension-volgenandt.de/#identity',
+      },
+      url: 'https://www.pension-volgenandt.de/willkommen/',
+      image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
     },
-    url: 'https://www.pension-volgenandt.de/willkommen/',
-    image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
-  },
-])
+    {
+      '@type': 'Person',
+      name: 'Ralf Volgenandt',
+      jobTitle: 'Gastgeber',
+      worksFor: {
+        '@id': 'https://www.pension-volgenandt.de/#identity',
+      },
+      url: 'https://www.pension-volgenandt.de/willkommen/',
+      image: 'https://www.pension-volgenandt.de/img/content/gastgeber-portrait.webp',
+    },
+  ],
+  'about-schema-de',
+)
 
 const { locale } = useLocale()
 </script>

--- a/app/pages/zimmer/[slug].vue
+++ b/app/pages/zimmer/[slug].vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { t } from '~/utils/translations'
 import { getAmenityLabel } from '~/utils/amenities'
+import { useJsonLd } from '~/composables/useJsonLd'
 
 const { locale } = useLocale()
 const route = useRoute()
@@ -79,12 +80,17 @@ useHead({
 })
 
 // HotelRoom + Offer Schema.org structured data
-useSchemaOrg([
+useJsonLd(
   {
-    '@type': ['HotelRoom', 'Product'],
+    '@type': 'HotelRoom',
+    '@id': `https://www.pension-volgenandt.de/zimmer/${room.value.slug}/#room`,
     name: room.value.name,
+    url: `https://www.pension-volgenandt.de/zimmer/${room.value.slug}/`,
     description: room.value.shortDescription,
-    image: `https://www.pension-volgenandt.de${room.value.heroImage}`,
+    image: [`https://www.pension-volgenandt.de${room.value.heroImage}`],
+    containedInPlace: {
+      '@id': 'https://www.pension-volgenandt.de/#identity',
+    },
     occupancy: {
       '@type': 'QuantitativeValue',
       maxValue: room.value.maxGuests,
@@ -103,12 +109,10 @@ useSchemaOrg([
         period.rates.map((rate) => ({
           '@type': 'Offer',
           name: `${room.value!.name} - ${period.label}`,
-          priceSpecification: {
-            '@type': 'UnitPriceSpecification',
-            price: rate.pricePerNight,
-            priceCurrency: 'EUR',
-            unitCode: 'DAY',
-          },
+          price: String(rate.pricePerNight),
+          priceCurrency: 'EUR',
+          availability: 'https://schema.org/InStock',
+          url: `https://www.pension-volgenandt.de/zimmer/${room.value!.slug}/`,
           businessFunction: 'http://purl.org/goodrelations/v1#LeaseOut',
           eligibleQuantity: {
             '@type': 'QuantitativeValue',
@@ -118,7 +122,8 @@ useSchemaOrg([
         })),
     ),
   },
-])
+  `room-schema-de-${slug}`,
+)
 </script>
 
 <template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -34,6 +34,16 @@ export default defineNuxtConfig({
     defaultLocale: 'de',
   },
 
+  // Structured data: keep nuxt-schema-org enabled (BreadcrumbNav relies on
+  // useBreadcrumbItems({ schemaOrg: true })), but disable its default
+  // WebPage/WebSite/Identity nodes. We emit those by hand via the useJsonLd
+  // composable so there is a single authoritative graph — this avoids
+  // duplicate WebSite entities and inconsistent (trailing-slash) canonical
+  // URLs in the generated output.
+  schemaOrg: {
+    defaults: false,
+  },
+
   // Sitemap configuration
   sitemap: {
     // Auto-discovers all prerendered routes
@@ -218,7 +228,10 @@ export default defineNuxtConfig({
       meta: [
         { charset: 'utf-8' },
         { name: 'viewport', content: 'width=device-width, initial-scale=1' },
-        { name: 'google-site-verification', content: 'ITqY-AGnrWeTeIoqq4benxxcLHWig6-niLio2SfJ30o' },
+        {
+          name: 'google-site-verification',
+          content: 'ITqY-AGnrWeTeIoqq4benxxcLHWig6-niLio2SfJ30o',
+        },
         { name: 'geo.region', content: 'DE-TH' },
         { name: 'geo.placename', content: 'Leinefelde-Worbis' },
         { name: 'geo.position', content: '51.4124;10.322' },

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -59,3 +59,31 @@
   AddOutputFilterByType DEFLATE application/xml application/xhtml+xml
   AddOutputFilterByType DEFLATE image/svg+xml
 </IfModule>
+
+# ─── 301 Redirects (legacy URLs from the previous site) ──────────
+# These old paths still 404 in Google Search Console. Redirect each to its
+# current equivalent to preserve link equity and clear the crawl errors.
+# REQUEST_URI is not URL-decoded, so the umlaut is matched as %C3%A4.
+<IfModule mod_rewrite.c>
+  RewriteEngine On
+
+  # /aktivitäten/ (umlaut) → /aktivitaeten/
+  RewriteCond %{REQUEST_URI} ^/aktivit%C3%A4ten/?$ [NC]
+  RewriteRule ^ /aktivitaeten/ [R=301,L]
+
+  # HTML sitemap guess → real XML sitemap
+  RewriteCond %{REQUEST_URI} ^/sitemap/?$ [NC]
+  RewriteRule ^ /sitemap.xml [R=301,L]
+
+  # /ferienwohnungen-zimmer/ → /ferienwohnungen/
+  RewriteCond %{REQUEST_URI} ^/ferienwohnungen-zimmer/?$ [NC]
+  RewriteRule ^ /ferienwohnungen/ [R=301,L]
+
+  # /kind-kegel/ → /familie/
+  RewriteCond %{REQUEST_URI} ^/kind-kegel/?$ [NC]
+  RewriteRule ^ /familie/ [R=301,L]
+
+  # /ein-kleiner-umweltgedanke/ → /nachhaltigkeit/
+  RewriteCond %{REQUEST_URI} ^/ein-kleiner-umweltgedanke/?$ [NC]
+  RewriteRule ^ /nachhaltigkeit/ [R=301,L]
+</IfModule>


### PR DESCRIPTION
Resolves the Google Search Console findings inspected on 2026-06-13.

## Structured data
- Migrate from `useSchemaOrg` to a hand-authored `useJsonLd` composable for explicit control of the JSON-LD graph.
- Disable nuxt-schema-org default WebSite/WebPage nodes (`schemaOrg.defaults: false`) to remove **duplicate `WebSite` entities** and inconsistent (trailing-slash) canonical URLs. Module stays enabled so `BreadcrumbNav` still emits `BreadcrumbList`.
- The `/picknick/` Product ("Picknick-Korb") now includes the required `image` and `brand` fields — this clears the **Merchant listings: missing image** critical error.

## Broken internal links (i18n)
- Register the `/willkommen`↔`/en/about` and `/buchung-danke`↔`/en/booking-thank-you` page pairs in `useLocale`. They were missing, so the language switcher linked to non-existent `/about` and `/booking-thank-you` (404). Link Checker: **3 errors → 0**.

## Legacy 404 redirects (.htaccess)
301-redirect 5 stale URLs from the previous site (no current code links to them):
- `/aktivitäten/` → `/aktivitaeten/`
- `/sitemap/` → `/sitemap.xml`
- `/ferienwohnungen-zimmer/` → `/ferienwohnungen/`
- `/kind-kegel/` → `/familie/`
- `/ein-kleiner-umweltgedanke/` → `/nachhaltigkeit/`

## Verification
- `nuxt generate` succeeds (251 routes, 0 link-checker errors)
- eslint / prettier / typecheck pass

> ⚠️ Merging to `main` deploys to IONOS. After deploy, re-run "Validate fix" in Search Console for the Merchant listings and 404 reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)