### PR TITLE
fix(seo): legacy 404 redirects via routeRules (GitHub Pages compatible)

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -44,6 +44,19 @@ export default defineNuxtConfig({
     defaults: false,
   },
 
+  // 301 redirects for legacy URLs from the previous site (still 404 in Google
+  // Search Console). Hosted on GitHub Pages, which ignores .htaccess, so these
+  // are emitted as static meta-refresh redirect pages by the Nitro static
+  // preset. The matching paths are added to nitro.prerender.routes below so a
+  // redirect file is generated for each.
+  routeRules: {
+    '/aktivitäten/': { redirect: { to: '/aktivitaeten/', statusCode: 301 } },
+    '/ferienwohnungen-zimmer/': { redirect: { to: '/ferienwohnungen/', statusCode: 301 } },
+    '/kind-kegel/': { redirect: { to: '/familie/', statusCode: 301 } },
+    '/ein-kleiner-umweltgedanke/': { redirect: { to: '/nachhaltigkeit/', statusCode: 301 } },
+    '/sitemap/': { redirect: { to: '/sitemap.xml', statusCode: 301 } },
+  },
+
   // Sitemap configuration
   sitemap: {
     // Auto-discovers all prerendered routes
@@ -214,6 +227,14 @@ export default defineNuxtConfig({
         // About / Willkommen pages
         '/willkommen/',
         '/en/about/',
+        // Legacy URLs from the previous site — prerendered so the routeRules
+        // above emit a static redirect file for each (GitHub Pages has no
+        // server-side redirects).
+        '/aktivitäten/',
+        '/ferienwohnungen-zimmer/',
+        '/kind-kegel/',
+        '/ein-kleiner-umweltgedanke/',
+        '/sitemap/',
       ],
       failOnError: false,
     },

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -59,31 +59,3 @@
   AddOutputFilterByType DEFLATE application/xml application/xhtml+xml
   AddOutputFilterByType DEFLATE image/svg+xml
 </IfModule>
-
-# ─── 301 Redirects (legacy URLs from the previous site) ──────────
-# These old paths still 404 in Google Search Console. Redirect each to its
-# current equivalent to preserve link equity and clear the crawl errors.
-# REQUEST_URI is not URL-decoded, so the umlaut is matched as %C3%A4.
-<IfModule mod_rewrite.c>
-  RewriteEngine On
-
-  # /aktivitäten/ (umlaut) → /aktivitaeten/
-  RewriteCond %{REQUEST_URI} ^/aktivit%C3%A4ten/?$ [NC]
-  RewriteRule ^ /aktivitaeten/ [R=301,L]
-
-  # HTML sitemap guess → real XML sitemap
-  RewriteCond %{REQUEST_URI} ^/sitemap/?$ [NC]
-  RewriteRule ^ /sitemap.xml [R=301,L]
-
-  # /ferienwohnungen-zimmer/ → /ferienwohnungen/
-  RewriteCond %{REQUEST_URI} ^/ferienwohnungen-zimmer/?$ [NC]
-  RewriteRule ^ /ferienwohnungen/ [R=301,L]
-
-  # /kind-kegel/ → /familie/
-  RewriteCond %{REQUEST_URI} ^/kind-kegel/?$ [NC]
-  RewriteRule ^ /familie/ [R=301,L]
-
-  # /ein-kleiner-umweltgedanke/ → /nachhaltigkeit/
-  RewriteCond %{REQUEST_URI} ^/ein-kleiner-umweltgedanke/?$ [NC]
-  RewriteRule ^ /nachhaltigkeit/ [R=301,L]
-</IfModule>


### PR DESCRIPTION
Follow-up to #27. The site is hosted on **GitHub Pages**, which ignores `.htaccess`, so the Apache redirect block from #27 never took effect.

Replaces it with Nitro `routeRules` redirects, and prerenders the legacy paths so a static meta-refresh redirect page is generated for each (the only redirect mechanism GitHub Pages supports).

Verified in a `--preset github_pages` build — all 5 redirect files generated with correct targets:
- `/aktivitäten/` → `/aktivitaeten/`
- `/ferienwohnungen-zimmer/` → `/ferienwohnungen/`
- `/kind-kegel/` → `/familie/`
- `/ein-kleiner-umweltgedanke/` → `/nachhaltigkeit/`
- `/sitemap/` → `/sitemap.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)