### PR TITLE
fix(seo): set canonical domain to www (CNAME)

### DIFF
--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-pension-volgenandt.de
+www.pension-volgenandt.de


### PR DESCRIPTION
Aligns the served domain with the site''s canonical/hreflang/sitemap (all www) and the Search Console property (www).

GitHub Pages was set to the apex `pension-volgenandt.de` and 301-redirected every `www` URL to apex — contradicting the `www` canonical tags and suppressing indexing. This switches the GitHub Pages custom domain to `www.pension-volgenandt.de` (apex will now redirect to www). The repo Pages setting is updated via API alongside this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)