### PR TITLE
Automated invoicing: editable review, Steuerbuero BCC, safer numbering, breakfast VAT split

### DIFF
--- a/scripts/combined-stats.mjs
+++ b/scripts/combined-stats.mjs
@@ -164,7 +164,7 @@ async function fetchBeds24(token, params) {
   do {
     const qs = new URLSearchParams({
       propertyId: BEDS24_PROPERTY_ID,
-      includeInvoice: 'false',
+      includeInvoiceItems: 'false',
       ...params,
     })
     if (pageToken) qs.set('pageToken', pageToken)
@@ -252,15 +252,26 @@ function aggregateBookings(bookings, rangeStart, rangeEnd) {
   let cancellations = 0
   let totalRevenue = 0
   let totalNightsInRange = 0
+  let blockedNightsInRange = 0
   let zeroPriceBookings = 0
   const byRoom = {}
   const byChannel = { Direkt: 0, 'Booking.com': 0, Website: 0, Airbnb: 0 }
 
   for (const b of bookings) {
-    // Blind bookings (status:"black") are manually blocked nights, not real
-    // reservations — exclude entirely so they don't inflate occupancy/nights
-    // or show up as cancellations/zero-price bookings.
-    if (isBlindBooking(b)) continue
+    // Blind bookings (status:"black") are manually blocked nights (vacation,
+    // maintenance, ...), not real reservations — exclude them from
+    // bookings/nights/revenue entirely. But also track how many nights they
+    // block so occupancy is measured against actually-available capacity:
+    // otherwise a room blocked for a week would drag occupancy below 100%
+    // even though every bookable night that week is full.
+    if (isBlindBooking(b)) {
+      const arrival = new Date(b.arrival).getTime()
+      const departure = new Date(b.departure).getTime()
+      const clampedStart = Math.max(arrival, rsMs)
+      const clampedEnd = Math.min(departure, reMs)
+      blockedNightsInRange += Math.max(0, Math.round((clampedEnd - clampedStart) / 86400000))
+      continue
+    }
 
     totalBookings++
     const isCancelled =
@@ -299,9 +310,11 @@ function aggregateBookings(bookings, rangeStart, rangeEnd) {
 
   const confirmed = totalBookings - cancellations
   const daysInRange = Math.round((reMs - rsMs) / 86400000)
-  const totalAvailable = TOTAL_UNITS * daysInRange
+  // Nights blocked by blind bookings aren't real availability — exclude them
+  // from the denominator so occupancy reflects only bookable nights.
+  const totalAvailable = Math.max(0, TOTAL_UNITS * daysInRange - blockedNightsInRange)
   const occupancyRate =
-    totalAvailable > 0 ? ((totalNightsInRange / totalAvailable) * 100).toFixed(1) : '0'
+    totalAvailable > 0 ? Math.min(100, (totalNightsInRange / totalAvailable) * 100).toFixed(1) : '0'
   const avgStay = confirmed > 0 ? (totalNightsInRange / confirmed).toFixed(1) : '0'
   const cancellationRate =
     totalBookings > 0 ? ((cancellations / totalBookings) * 100).toFixed(1) : '0'
@@ -442,12 +455,12 @@ async function collectRevenueHistory(token) {
         fetchBeds24(token, {
           arrivalTo: monthEndStr,
           departureFrom: monthStartStr,
-          includeInvoice: 'true',
+          includeInvoiceItems: 'true',
         }).catch(() => []),
         fetchBeds24(token, {
           arrivalTo: monthEndStr,
           departureFrom: monthStartStr,
-          includeInvoice: 'true',
+          includeInvoiceItems: 'true',
           status: 'cancelled',
         }).catch(() => []),
       ])

--- a/server/beds24-api.php
+++ b/server/beds24-api.php
@@ -62,9 +62,17 @@ class Beds24Api {
         $bookings = $response['data']['data'] ?? [];
 
         // Filter: only confirmed/new with outstanding balance
+        // Beds24 v2 /bookings never populates invoice.balance or balance for
+        // this account — fall back to price minus deposit (amount paid).
         return array_values(array_filter($bookings, function (array $b): bool {
-            $status  = strtolower((string)($b['status'] ?? ''));
-            $balance = (float)($b['invoice']['balance'] ?? $b['balance'] ?? $b['price'] ?? 0);
+            $status = strtolower((string)($b['status'] ?? ''));
+            if (isset($b['invoice']['balance'])) {
+                $balance = (float)$b['invoice']['balance'];
+            } elseif (isset($b['balance'])) {
+                $balance = (float)$b['balance'];
+            } else {
+                $balance = (float)($b['price'] ?? 0) - (float)($b['deposit'] ?? 0);
+            }
             return in_array($status, ['confirmed', 'new'], true) && $balance > 0.01;
         }));
     }

--- a/server/config.php.example
+++ b/server/config.php.example
@@ -22,6 +22,9 @@ define('INVOICE_WEBHOOK_SECRET', 'CHANGE_ME');
 define('ADMIN_EMAIL',    'kontakt@pension-volgenandt.de');
 define('MAIL_FROM_NAME', 'Simone & Ralf Volgenandt');
 
+// Steuerbüro — receives a BCC copy of every invoice PDF sent to a guest
+define('STEUERBUERO_EMAIL', 'CHANGE_ME');
+
 // Base URL of the server-side API (no trailing slash)
 define('INVOICE_BASE_URL', 'https://api.pension-volgenandt.de');
 

--- a/server/config.php.example
+++ b/server/config.php.example
@@ -38,6 +38,16 @@ define('BEDS24_ROOM_NAMES', [
     656180 => 'Ferienwohnung Schöne Aussicht',
 ]);
 
+// Breakfast tiers: per-person gross price → Speisen (7%) / Getränke (19%) split.
+// Beds24 only ever sends one combined "Frühstück" amount — this is how the
+// invoice reconstructs the legally required MwSt split by price match.
+// (Deliberately a list with an explicit 'price' field, not price-as-array-key —
+// PHP silently truncates float array keys to int.)
+define('BREAKFAST_TIERS', [
+    ['price' => 10.00, 'food' => 7.00,  'drink' => 3.00],  // Frühstück (normal)
+    ['price' => 15.00, 'food' => 10.00, 'drink' => 5.00],  // Frühstück Genießer
+]);
+
 // Bank details (Kreissparkasse Eichsfeld)
 define('BANK_NAME', 'Kreissparkasse Eichsfeld');
 define('BANK_IBAN', 'DE28820570701106230767');

--- a/server/invoice-draft.php
+++ b/server/invoice-draft.php
@@ -312,8 +312,17 @@ function calcTotals(array $items): array {
 }
 
 function extractBalance(array $booking): float {
-    // Beds24 v2: balance is in invoice.balance; fall back to top-level price
-    return (float)($booking['invoice']['balance'] ?? $booking['balance'] ?? $booking['price'] ?? 0);
+    // Beds24 v2 /bookings never populates invoice.balance or balance for this
+    // account — only price (total) and deposit (paid to date) are reliable.
+    if (isset($booking['invoice']['balance'])) {
+        return (float)$booking['invoice']['balance'];
+    }
+    if (isset($booking['balance'])) {
+        return (float)$booking['balance'];
+    }
+    $price   = (float)($booking['price']   ?? 0);
+    $deposit = (float)($booking['deposit'] ?? 0);
+    return round($price - $deposit, 2);
 }
 
 // ---------------------------------------------------------------------------

--- a/server/invoice-draft.php
+++ b/server/invoice-draft.php
@@ -59,6 +59,7 @@ function generateInvoiceDraftIfNeeded(int $bookingId, array $webhookItems = []):
     }
 
     $draft = buildInvoiceDraft($booking, $webhookItems);
+    $draft['prePaid'] = $balance <= 0.01;
     $token = $draft['token'];
 
     if (!is_dir(INV_DRAFTS_DIR)) {
@@ -72,62 +73,17 @@ function generateInvoiceDraftIfNeeded(int $bookingId, array $webhookItems = []):
 
     markBookingProcessed($bookingId, $token);
 
-    // Booking already fully paid at webhook time — nothing left for Simone to
-    // check, so send the Buchungsbestätigung (+ paid invoice) straight to the
-    // guest instead of waiting on manual approval.
-    if ($balance <= 0.01) {
-        $sendResult = autoSendPaidBookingDraft($draft, $path);
-        draftLog($bookingId, 'auto_sent', "token={$token} scenario={$draft['scenario']} emailSent=" . ($sendResult['emailSent'] ? '1' : '0'));
+    draftLog($bookingId, 'created', "token={$token} scenario={$draft['scenario']} balance={$balance} prePaid=" . ($draft['prePaid'] ? '1' : '0'));
 
-        return [
-            'ok'       => true,
-            'skipped'  => false,
-            'token'    => $token,
-            'scenario' => $draft['scenario'],
-            'autoSent' => true,
-        ];
-    }
-
-    draftLog($bookingId, 'created', "token={$token} scenario={$draft['scenario']} balance={$balance}");
-
-    // Notify Simone so she can review and approve
+    // Notify Simone so she can review and approve — always, even when the
+    // booking is already fully paid at webhook time. A wrong Rechnungsnummer
+    // is exactly the kind of mistake a payment-only check would miss, so
+    // nothing ever reaches a guest without her clicking Genehmigen.
     require_once __DIR__ . '/invoice-mailer.php';
     $notified = notifySimone($draft);
     draftLog($bookingId, 'notify', "simone_email=" . ($notified ? 'sent' : 'failed'));
 
     return ['ok' => true, 'skipped' => false, 'token' => $token, 'scenario' => $draft['scenario']];
-}
-
-/**
- * Auto-approve and send a draft for a booking that was already fully paid
- * when the webhook arrived. Skips the Simone review step entirely; she gets
- * an FYI email afterwards instead of an approval request.
- */
-function autoSendPaidBookingDraft(array $draft, string $draftPath): array {
-    require_once __DIR__ . '/invoice-pdf.php';
-    require_once __DIR__ . '/invoice-mailer.php';
-
-    $draft['invoiceDate'] = date('Y-m-d');
-    $draft['approvedAt']  = date('c');
-    $draft['status']      = 'approved';
-    $draft['note']        = 'Automatisch versendet – Buchung war bei Eingang bereits vollständig bezahlt.';
-
-    $pdfBytes = generateInvoicePdf($draft);
-
-    $sentDir = __DIR__ . '/invoices/sent';
-    if (!is_dir($sentDir)) {
-        mkdir($sentDir, 0750, true);
-    }
-    file_put_contents($sentDir . '/' . $draft['token'] . '.pdf', $pdfBytes);
-
-    $emailSent               = sendInvoiceToGuest($draft, $pdfBytes, true);
-    $draft['guestEmailSent'] = $emailSent;
-
-    file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
-
-    notifySimoneAutoSent($draft, $emailSent);
-
-    return ['emailSent' => $emailSent];
 }
 
 // ---------------------------------------------------------------------------
@@ -136,7 +92,6 @@ function autoSendPaidBookingDraft(array $draft, string $draftPath): array {
 
 function buildInvoiceDraft(array $booking, array $webhookItems = []): array {
     $token    = makeUuid();
-    $invNum   = nextInvoiceNumber();
     $scenario = detectScenario($booking);
     $guest    = parseGuest($booking);
     $stay     = parseStay($booking);
@@ -149,7 +104,9 @@ function buildInvoiceDraft(array $booking, array $webhookItems = []): array {
         'status'        => 'pending',
         'scenario'      => $scenario,
         'bookingId'     => (int)($booking['id'] ?? 0),
-        'invoiceNumber' => $invNum,
+        // Assigned only when Simone approves (see tryAssignInvoiceNumber) —
+        // never at draft creation, so a rejected draft never burns a number.
+        'invoiceNumber' => null,
         'invoiceDate'   => null,
         'guest'         => $guest,
         'stay'          => $stay,
@@ -226,9 +183,15 @@ function parseLineItems(array $booking, array $webhookItems = []): array {
     $invoiceItems = $booking['invoice']['items'] ?? $booking['invoiceItems'] ?? $webhookItems;
     $basePrice    = (float)($booking['price'] ?? $booking['totalPrice'] ?? 0);
 
+    // Always name the specific room on the accommodation line — a booking never
+    // covers more than one room, but guests/companies often book several rooms
+    // together, and each room gets its own invoice. Without the room name those
+    // invoices are indistinguishable ("Übernachtung" on all of them).
+    $roomLabel = 'Übernachtung – ' . resolveRoomName($booking);
+
     // No itemized invoice — fall back to room price only
     if (empty($invoiceItems)) {
-        return $basePrice > 0 ? [makeLineItem('Übernachtung', $basePrice, 7)] : [];
+        return $basePrice > 0 ? [makeLineItem($roomLabel, $basePrice, 7)] : [];
     }
 
     $accommodationGross = 0.0;
@@ -256,9 +219,9 @@ function parseLineItems(array $booking, array $webhookItems = []): array {
     $items = [];
 
     if ($accommodationGross > 0.01) {
-        $items[] = makeLineItem('Übernachtung', $accommodationGross, 7);
+        $items[] = makeLineItem($roomLabel, $accommodationGross, 7);
     } elseif (empty($breakfastItems) && $basePrice > 0) {
-        $items[] = makeLineItem('Übernachtung', $basePrice, 7);
+        $items[] = makeLineItem($roomLabel, $basePrice, 7);
     }
 
     return array_merge($items, $breakfastItems);
@@ -326,36 +289,104 @@ function extractBalance(array $booking): float {
 }
 
 // ---------------------------------------------------------------------------
-// Invoice number (atomic file-lock increment)
+// Invoice number — assigned at approval time, not draft creation, so a
+// rejected/discarded draft never burns a number and numbers stay in the
+// order invoices are actually issued.
 // ---------------------------------------------------------------------------
 
-function nextInvoiceNumber(): string {
-    $file = INV_COUNTER_FILE;
-    $lock = $file . '.lock';
+/**
+ * Read-only look at what the next invoice number would currently be. Used
+ * to prefill the editable Rechnungsnummer field on the review page — this is
+ * only a suggestion, nothing is reserved until tryAssignInvoiceNumber().
+ */
+function peekNextInvoiceNumber(): string {
+    $data  = json_decode(@file_get_contents(INV_COUNTER_FILE) ?: '{}', true) ?? [];
+    $year  = (int)($data['year'] ?? date('Y'));
+    $count = (int)($data['counter'] ?? 0);
 
-    for ($attempt = 0; $attempt < 10; $attempt++) {
-        $fp = @fopen($lock, 'x');
-        if ($fp !== false) { fclose($fp); break; }
-        usleep(100_000);
+    if ($year !== (int)date('Y')) {
+        $count = 0;
+    }
+
+    return sprintf('%d-%03d', (int)date('Y'), $count + 1);
+}
+
+/**
+ * Does any other draft already carry this invoice number?
+ */
+function isInvoiceNumberUsed(string $num, string $excludeToken): bool {
+    foreach (glob(INV_DRAFTS_DIR . '/*.json') ?: [] as $file) {
+        if (basename($file, '.json') === $excludeToken) continue;
+        $data = json_decode(@file_get_contents($file) ?: '', true);
+        if (($data['invoiceNumber'] ?? null) === $num) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Atomically validate, reserve, and persist a specific invoice number onto
+ * a draft. The whole check-and-write happens while holding the counter
+ * lock, so two concurrent approvals can never end up with the same number.
+ * Returns false (draft left untouched) if the number is malformed or
+ * already used by another draft — callers must not proceed on false.
+ */
+function tryAssignInvoiceNumber(array &$draft, string $requestedNumber, string $draftPath): bool {
+    if (!preg_match('/^(\d{4})-(\d{3,})$/', $requestedNumber, $m)) {
+        return false;
+    }
+    $year  = (int)$m[1];
+    $count = (int)$m[2];
+
+    $lock = INV_COUNTER_FILE . '.lock';
+    if (!acquireCounterLock($lock)) {
+        throw new \RuntimeException('Could not acquire invoice-counter lock');
     }
 
     try {
-        $data  = json_decode(@file_get_contents($file) ?: '{}', true) ?? [];
-        $year  = (int)($data['year']    ?? date('Y'));
-        $count = (int)($data['counter'] ?? 0);
-
-        if ($year !== (int)date('Y')) {
-            $year  = (int)date('Y');
-            $count = 0;
+        if (isInvoiceNumberUsed($requestedNumber, $draft['token'])) {
+            return false;
         }
 
-        $count++;
-        file_put_contents($file, json_encode(['year' => $year, 'counter' => $count], JSON_PRETTY_PRINT));
+        $data         = json_decode(@file_get_contents(INV_COUNTER_FILE) ?: '{}', true) ?? [];
+        $currentYear  = (int)($data['year']    ?? $year);
+        $currentCount = (int)($data['counter'] ?? 0);
 
-        return sprintf('%d-%03d', $year, $count);
+        if ($currentYear !== $year || $count > $currentCount) {
+            file_put_contents(INV_COUNTER_FILE, json_encode(['year' => $year, 'counter' => $count], JSON_PRETTY_PRINT));
+        }
+
+        $draft['invoiceNumber'] = $requestedNumber;
+        file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+        return true;
     } finally {
         @unlink($lock);
     }
+}
+
+/**
+ * Acquire the invoice-counter lock, recovering from a stale lock file left
+ * behind by a crashed request (anything older than 10s is treated as
+ * orphaned). Returns false if the lock could not be acquired — callers must
+ * treat that as a hard failure and never proceed without it, since that is
+ * exactly how two invoices could end up with the same number.
+ */
+function acquireCounterLock(string $lock): bool {
+    if (file_exists($lock) && (time() - (int)@filemtime($lock)) > 10) {
+        @unlink($lock);
+    }
+
+    for ($attempt = 0; $attempt < 20; $attempt++) {
+        $fp = @fopen($lock, 'x');
+        if ($fp !== false) {
+            fclose($fp);
+            return true;
+        }
+        usleep(100_000);
+    }
+    return false;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/invoice-draft.php
+++ b/server/invoice-draft.php
@@ -120,7 +120,7 @@ function autoSendPaidBookingDraft(array $draft, string $draftPath): array {
     }
     file_put_contents($sentDir . '/' . $draft['token'] . '.pdf', $pdfBytes);
 
-    $emailSent               = sendInvoiceToGuest($draft, $pdfBytes);
+    $emailSent               = sendInvoiceToGuest($draft, $pdfBytes, true);
     $draft['guestEmailSent'] = $emailSent;
 
     file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));

--- a/server/invoice-draft.php
+++ b/server/invoice-draft.php
@@ -58,11 +58,6 @@ function generateInvoiceDraftIfNeeded(int $bookingId, array $webhookItems = []):
         return ['ok' => true, 'skipped' => true, 'reason' => 'status_not_applicable'];
     }
 
-    if ($balance <= 0.01) {
-        draftLog($bookingId, 'skip', "balance={$balance} too low");
-        return ['ok' => true, 'skipped' => true, 'reason' => 'no_balance'];
-    }
-
     $draft = buildInvoiceDraft($booking, $webhookItems);
     $token = $draft['token'];
 
@@ -76,6 +71,23 @@ function generateInvoiceDraftIfNeeded(int $bookingId, array $webhookItems = []):
     }
 
     markBookingProcessed($bookingId, $token);
+
+    // Booking already fully paid at webhook time — nothing left for Simone to
+    // check, so send the Buchungsbestätigung (+ paid invoice) straight to the
+    // guest instead of waiting on manual approval.
+    if ($balance <= 0.01) {
+        $sendResult = autoSendPaidBookingDraft($draft, $path);
+        draftLog($bookingId, 'auto_sent', "token={$token} scenario={$draft['scenario']} emailSent=" . ($sendResult['emailSent'] ? '1' : '0'));
+
+        return [
+            'ok'       => true,
+            'skipped'  => false,
+            'token'    => $token,
+            'scenario' => $draft['scenario'],
+            'autoSent' => true,
+        ];
+    }
+
     draftLog($bookingId, 'created', "token={$token} scenario={$draft['scenario']} balance={$balance}");
 
     // Notify Simone so she can review and approve
@@ -84,6 +96,38 @@ function generateInvoiceDraftIfNeeded(int $bookingId, array $webhookItems = []):
     draftLog($bookingId, 'notify', "simone_email=" . ($notified ? 'sent' : 'failed'));
 
     return ['ok' => true, 'skipped' => false, 'token' => $token, 'scenario' => $draft['scenario']];
+}
+
+/**
+ * Auto-approve and send a draft for a booking that was already fully paid
+ * when the webhook arrived. Skips the Simone review step entirely; she gets
+ * an FYI email afterwards instead of an approval request.
+ */
+function autoSendPaidBookingDraft(array $draft, string $draftPath): array {
+    require_once __DIR__ . '/invoice-pdf.php';
+    require_once __DIR__ . '/invoice-mailer.php';
+
+    $draft['invoiceDate'] = date('Y-m-d');
+    $draft['approvedAt']  = date('c');
+    $draft['status']      = 'approved';
+    $draft['note']        = 'Automatisch versendet – Buchung war bei Eingang bereits vollständig bezahlt.';
+
+    $pdfBytes = generateInvoicePdf($draft);
+
+    $sentDir = __DIR__ . '/invoices/sent';
+    if (!is_dir($sentDir)) {
+        mkdir($sentDir, 0750, true);
+    }
+    file_put_contents($sentDir . '/' . $draft['token'] . '.pdf', $pdfBytes);
+
+    $emailSent               = sendInvoiceToGuest($draft, $pdfBytes);
+    $draft['guestEmailSent'] = $emailSent;
+
+    file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+
+    notifySimoneAutoSent($draft, $emailSent);
+
+    return ['emailSent' => $emailSent];
 }
 
 // ---------------------------------------------------------------------------

--- a/server/invoice-draft.php
+++ b/server/invoice-draft.php
@@ -210,7 +210,7 @@ function parseLineItems(array $booking, array $webhookItems = []): array {
         if ($cleaned !== '') $desc = $cleaned;
 
         if (isBreakfastItem($desc)) {
-            $breakfastItems[] = makeLineItem($desc ?: 'Frühstück', $gross, 19, $qty, $unit);
+            $breakfastItems = array_merge($breakfastItems, splitBreakfastItem($qty, $unit));
         } else {
             $accommodationGross += $gross;
         }
@@ -238,6 +238,34 @@ function isBreakfastItem(string $desc): bool {
     return str_contains($lower, 'frühstück')
         || str_contains($lower, 'breakfast')
         || str_contains($lower, 'fruehstueck');
+}
+
+/**
+ * Split a per-person breakfast charge into the legally required Speisen
+ * (7%) / Getränke (19%) line items. Beds24 only ever sends one combined
+ * "Frühstück" amount, so the split is reconstructed by matching the
+ * per-person price against BREAKFAST_TIERS (server/config.php) — a fixed
+ * absolute Speisen/Getränke split per tier, not a percentage ratio, since
+ * that's how the two breakfast products (normal/Genießer) are actually priced.
+ */
+function splitBreakfastItem(float $qty, float $unitGross): array {
+    $tiers = defined('BREAKFAST_TIERS') ? BREAKFAST_TIERS : [];
+
+    foreach ($tiers as $tier) {
+        if (abs($unitGross - (float)$tier['price']) < 0.05) {
+            return [
+                makeLineItem('Frühstück – Speisen',  $tier['food']  * $qty, 7,  $qty, $tier['food']),
+                makeLineItem('Frühstück – Getränke', $tier['drink'] * $qty, 19, $qty, $tier['drink']),
+            ];
+        }
+    }
+
+    // Unknown price — don't guess a split. One clearly-flagged line so it
+    // can't be silently approved wrong; Simone can fix it in the editable
+    // review form.
+    return [
+        makeLineItem('Frühstück (Preis unbekannt – bitte Aufteilung prüfen!)', $unitGross * $qty, 19, $qty, $unitGross),
+    ];
 }
 
 function makeLineItem(string $desc, float $gross, int $vatRate, float $qty = 1.0, float $unitGross = 0.0): array {

--- a/server/invoice-mailer.php
+++ b/server/invoice-mailer.php
@@ -4,7 +4,8 @@
  *
  * Public API:
  *   sendMail(string $to, string $toName, string $subject, string $html, string $text, array $attachments): bool
- *   notifySimone(array $draft): bool   — sends review-link email to ADMIN_EMAIL
+ *   notifySimone(array $draft): bool           — sends review-link email to ADMIN_EMAIL
+ *   notifySimoneAutoSent(array $draft, bool $emailSent): bool — FYI for auto-sent (fully paid) bookings
  *   sendInvoiceToGuest(array $draft, string $pdfBytes): bool
  */
 
@@ -100,6 +101,44 @@ function notifySimone(array $draft): bool {
   <p style="margin-top:20px;font-size:12px;color:#aaa;">
     Oder Link kopieren:<br>' . htmlspecialchars($link) . '
   </p>
+</div>';
+
+    return sendMail(ADMIN_EMAIL, 'Simone Volgenandt', $subject, $html);
+}
+
+// ---------------------------------------------------------------------------
+// FYI notice: booking was already paid in full, confirmation auto-sent
+// ---------------------------------------------------------------------------
+
+function notifySimoneAutoSent(array $draft, bool $emailSent): bool {
+    $guest   = $draft['guest'];
+    $stay    = $draft['stay'];
+    $totals  = $draft['totals'];
+    $token   = $draft['token'];
+    $invNum  = $draft['invoiceNumber'] ?? '';
+    $total   = number_format((float)($totals['total'] ?? 0), 2, ',', '.');
+    $link    = INVOICE_BASE_URL . '/invoice-review.php?token=' . urlencode($token);
+
+    $checkIn  = $stay['checkIn']  ? date('d.m.Y', strtotime($stay['checkIn']))  : '–';
+    $checkOut = $stay['checkOut'] ? date('d.m.Y', strtotime($stay['checkOut'])) : '–';
+
+    $subject = 'Buchungsbestätigung automatisch versendet: ' . ($guest['name'] ?? '') . ' – ' . $total . ' €';
+    $statusLine = $emailSent
+        ? 'Die Buchungsbestätigung wurde bereits automatisch an den Gast gesendet.'
+        : 'Achtung: Der Gast hat keine E-Mail-Adresse hinterlegt — die Bestätigung konnte nicht gesendet werden.';
+
+    $html = '
+<div style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:540px;">
+  <h2 style="color:#3d5a3e;margin:0 0 8px;">Buchung bereits vollständig bezahlt</h2>
+  <p style="margin:0 0 16px;line-height:1.6;">' . htmlspecialchars($statusLine) . ' Keine Aktion erforderlich — nur zur Info.</p>
+  <table style="width:100%;border-collapse:collapse;margin-bottom:20px;">
+    <tr><td style="padding:6px 10px;color:#666;width:130px;">Rechnungs-Nr.</td><td style="padding:6px 10px;"><strong>' . htmlspecialchars($invNum) . '</strong></td></tr>
+    <tr style="background:#f9f9f9;"><td style="padding:6px 10px;color:#666;">Gast</td><td style="padding:6px 10px;">' . htmlspecialchars($guest['name'] ?? '') . '</td></tr>
+    <tr><td style="padding:6px 10px;color:#666;">Zimmer</td><td style="padding:6px 10px;">' . htmlspecialchars($stay['roomName'] ?? '') . '</td></tr>
+    <tr style="background:#f9f9f9;"><td style="padding:6px 10px;color:#666;">Zeitraum</td><td style="padding:6px 10px;">' . $checkIn . ' – ' . $checkOut . ' (' . (int)($stay['nights'] ?? 0) . ' Nächte)</td></tr>
+    <tr><td style="padding:6px 10px;color:#666;">Betrag (bezahlt)</td><td style="padding:6px 10px;"><strong>' . $total . ' €</strong></td></tr>
+  </table>
+  <a href="' . htmlspecialchars($link) . '" style="display:inline-block;background:#3d5a3e;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Rechnung ansehen →</a>
 </div>';
 
     return sendMail(ADMIN_EMAIL, 'Simone Volgenandt', $subject, $html);

--- a/server/invoice-mailer.php
+++ b/server/invoice-mailer.php
@@ -5,7 +5,6 @@
  * Public API:
  *   sendMail(string $to, string $toName, string $subject, string $html, string $text, array $attachments): bool
  *   notifySimone(array $draft): bool           — sends review-link email to ADMIN_EMAIL
- *   notifySimoneAutoSent(array $draft, bool $emailSent): bool — FYI for auto-sent (fully paid) bookings
  *   sendInvoiceToGuest(array $draft, string $pdfBytes): bool
  */
 
@@ -22,7 +21,8 @@ function sendMail(
     string $html,
     string $text = '',
     array  $attachments = [],
-    array  $cc = []
+    array  $cc = [],
+    array  $bcc = []
 ): bool {
     $autoload = __DIR__ . '/vendor/autoload.php';
     if (!file_exists($autoload)) {
@@ -46,6 +46,9 @@ function sendMail(
         $mail->addAddress($to, $toName);
         foreach ($cc as $ccAddr) {
             $mail->addCC($ccAddr);
+        }
+        foreach ($bcc as $bccAddr) {
+            $mail->addBCC($bccAddr);
         }
         $mail->Subject = $subject;
         $mail->isHTML(true);
@@ -74,24 +77,32 @@ function sendMail(
 // ---------------------------------------------------------------------------
 
 function notifySimone(array $draft): bool {
-    $guest   = $draft['guest'];
-    $stay    = $draft['stay'];
-    $totals  = $draft['totals'];
-    $token   = $draft['token'];
-    $invNum  = $draft['invoiceNumber'] ?? '';
-    $total   = number_format((float)($totals['total'] ?? 0), 2, ',', '.');
-    $link    = INVOICE_BASE_URL . '/invoice-review.php?token=' . urlencode($token);
+    $guest     = $draft['guest'];
+    $stay      = $draft['stay'];
+    $totals    = $draft['totals'];
+    $token     = $draft['token'];
+    $prePaid   = !empty($draft['prePaid']);
+    $suggested = peekNextInvoiceNumber();
+    $total     = number_format((float)($totals['total'] ?? 0), 2, ',', '.');
+    $link      = INVOICE_BASE_URL . '/invoice-review.php?token=' . urlencode($token);
 
     $checkIn  = $stay['checkIn']  ? date('d.m.Y', strtotime($stay['checkIn']))  : '–';
     $checkOut = $stay['checkOut'] ? date('d.m.Y', strtotime($stay['checkOut'])) : '–';
 
-    $subject = 'Neue Rechnung prüfen: ' . ($guest['name'] ?? '') . ' – ' . $total . ' €';
+    $subject = ($prePaid ? 'Bereits bezahlt – Rechnungsnummer prüfen: ' : 'Neue Rechnung prüfen: ')
+        . ($guest['name'] ?? '') . ' – ' . $total . ' €';
+
+    $heading = $prePaid ? 'Bereits bezahlt – bitte nur kurz prüfen' : 'Neuer Rechnungsentwurf';
+    $intro   = $prePaid
+        ? '<p style="margin:0 0 16px;line-height:1.6;">Diese Buchung wurde bereits vollständig bezahlt. Bitte kurz die Rechnungsnummer prüfen und freigeben — der Haken &bdquo;Bereits bezahlt&ldquo; ist schon gesetzt.</p>'
+        : '';
 
     $html = '
 <div style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:540px;">
-  <h2 style="color:#3d5a3e;margin:0 0 16px;">Neuer Rechnungsentwurf</h2>
+  <h2 style="color:#3d5a3e;margin:0 0 16px;">' . $heading . '</h2>
+  ' . $intro . '
   <table style="width:100%;border-collapse:collapse;margin-bottom:20px;">
-    <tr><td style="padding:6px 10px;color:#666;width:130px;">Rechnungs-Nr.</td><td style="padding:6px 10px;"><strong>' . htmlspecialchars($invNum) . '</strong></td></tr>
+    <tr><td style="padding:6px 10px;color:#666;width:170px;">Voraussichtl. Rechnungs-Nr.</td><td style="padding:6px 10px;"><strong>' . htmlspecialchars($suggested) . '</strong></td></tr>
     <tr style="background:#f9f9f9;"><td style="padding:6px 10px;color:#666;">Gast</td><td style="padding:6px 10px;">' . htmlspecialchars($guest['name'] ?? '') . '</td></tr>
     <tr><td style="padding:6px 10px;color:#666;">Zimmer</td><td style="padding:6px 10px;">' . htmlspecialchars($stay['roomName'] ?? '') . '</td></tr>
     <tr style="background:#f9f9f9;"><td style="padding:6px 10px;color:#666;">Zeitraum</td><td style="padding:6px 10px;">' . $checkIn . ' – ' . $checkOut . ' (' . (int)($stay['nights'] ?? 0) . ' Nächte)</td></tr>
@@ -101,44 +112,6 @@ function notifySimone(array $draft): bool {
   <p style="margin-top:20px;font-size:12px;color:#aaa;">
     Oder Link kopieren:<br>' . htmlspecialchars($link) . '
   </p>
-</div>';
-
-    return sendMail(ADMIN_EMAIL, 'Simone Volgenandt', $subject, $html);
-}
-
-// ---------------------------------------------------------------------------
-// FYI notice: booking was already paid in full, confirmation auto-sent
-// ---------------------------------------------------------------------------
-
-function notifySimoneAutoSent(array $draft, bool $emailSent): bool {
-    $guest   = $draft['guest'];
-    $stay    = $draft['stay'];
-    $totals  = $draft['totals'];
-    $token   = $draft['token'];
-    $invNum  = $draft['invoiceNumber'] ?? '';
-    $total   = number_format((float)($totals['total'] ?? 0), 2, ',', '.');
-    $link    = INVOICE_BASE_URL . '/invoice-review.php?token=' . urlencode($token);
-
-    $checkIn  = $stay['checkIn']  ? date('d.m.Y', strtotime($stay['checkIn']))  : '–';
-    $checkOut = $stay['checkOut'] ? date('d.m.Y', strtotime($stay['checkOut'])) : '–';
-
-    $subject = 'Buchungsbestätigung automatisch versendet: ' . ($guest['name'] ?? '') . ' – ' . $total . ' €';
-    $statusLine = $emailSent
-        ? 'Die Buchungsbestätigung wurde bereits automatisch an den Gast gesendet.'
-        : 'Achtung: Der Gast hat keine E-Mail-Adresse hinterlegt — die Bestätigung konnte nicht gesendet werden.';
-
-    $html = '
-<div style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:540px;">
-  <h2 style="color:#3d5a3e;margin:0 0 8px;">Buchung bereits vollständig bezahlt</h2>
-  <p style="margin:0 0 16px;line-height:1.6;">' . htmlspecialchars($statusLine) . ' Keine Aktion erforderlich — nur zur Info.</p>
-  <table style="width:100%;border-collapse:collapse;margin-bottom:20px;">
-    <tr><td style="padding:6px 10px;color:#666;width:130px;">Rechnungs-Nr.</td><td style="padding:6px 10px;"><strong>' . htmlspecialchars($invNum) . '</strong></td></tr>
-    <tr style="background:#f9f9f9;"><td style="padding:6px 10px;color:#666;">Gast</td><td style="padding:6px 10px;">' . htmlspecialchars($guest['name'] ?? '') . '</td></tr>
-    <tr><td style="padding:6px 10px;color:#666;">Zimmer</td><td style="padding:6px 10px;">' . htmlspecialchars($stay['roomName'] ?? '') . '</td></tr>
-    <tr style="background:#f9f9f9;"><td style="padding:6px 10px;color:#666;">Zeitraum</td><td style="padding:6px 10px;">' . $checkIn . ' – ' . $checkOut . ' (' . (int)($stay['nights'] ?? 0) . ' Nächte)</td></tr>
-    <tr><td style="padding:6px 10px;color:#666;">Betrag (bezahlt)</td><td style="padding:6px 10px;"><strong>' . $total . ' €</strong></td></tr>
-  </table>
-  <a href="' . htmlspecialchars($link) . '" style="display:inline-block;background:#3d5a3e;color:#fff;padding:12px 24px;border-radius:6px;text-decoration:none;font-weight:600;font-size:14px;">Rechnung ansehen →</a>
 </div>';
 
     return sendMail(ADMIN_EMAIL, 'Simone Volgenandt', $subject, $html);
@@ -290,7 +263,12 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
 </div>';
     }
 
+    $bcc = [ADMIN_EMAIL];
+    if (defined('STEUERBUERO_EMAIL') && STEUERBUERO_EMAIL !== '') {
+        $bcc[] = STEUERBUERO_EMAIL;
+    }
+
     return sendMail($email, $name, $subject, $html, '', [
         ['data' => $pdfBytes, 'filename' => 'Rechnung-' . $invNum . '.pdf', 'mime' => 'application/pdf'],
-    ], [ADMIN_EMAIL]);
+    ], [], $bcc);
 }

--- a/server/invoice-mailer.php
+++ b/server/invoice-mailer.php
@@ -148,7 +148,7 @@ function notifySimoneAutoSent(array $draft, bool $emailSent): bool {
 // Send approved invoice PDF to the guest
 // ---------------------------------------------------------------------------
 
-function sendInvoiceToGuest(array $draft, string $pdfBytes): bool {
+function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false): bool {
     $guest    = $draft['guest'];
     $stay     = $draft['stay'];
     $issuer   = $draft['issuer'];
@@ -171,36 +171,45 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes): bool {
     $total     = number_format((float)($totals['total'] ?? 0), 2, ',', '.') . '&nbsp;&euro;';
     $personStr = $adults . ' Erwachsene' . ($children > 0 ? ', ' . $children . ' Kinder' : '');
 
-    // Bank transfer block
+    // Payment section: either "please pay" (bank/PayPal/cancellation warning)
+    // or, for bookings already paid in full via PayPal, a receipt confirmation.
     $bankHtml = '';
-    if (!empty($issuer['iban'])) {
-        $bn       = !empty($issuer['bankName']) ? $esc($issuer['bankName']) . '<br>' : '';
-        $bic      = !empty($issuer['bic'])      ? 'BIC: ' . $esc($issuer['bic']) . '<br>' : '';
-        $bankHtml = '
+    $ppBtn    = '';
+    $cancelNote = '';
+    $paidNote   = '';
+
+    if ($isPaid) {
+        $paidNote = '
+<p style="background:#eafaf1;border-left:4px solid #27ae60;padding:12px 16px;border-radius:4px;font-size:13px;line-height:1.7;margin:0 0 20px;">
+  <strong>✓ Zahlung eingegangen.</strong> Wir haben Ihre Zahlung in Höhe von ' . $total . ' per PayPal erhalten — vielen Dank! Die Rechnung im Anhang dient als Beleg, es ist keine weitere Zahlung erforderlich.
+</p>';
+    } else {
+        if (!empty($issuer['iban'])) {
+            $bn       = !empty($issuer['bankName']) ? $esc($issuer['bankName']) . '<br>' : '';
+            $bic      = !empty($issuer['bic'])      ? 'BIC: ' . $esc($issuer['bic']) . '<br>' : '';
+            $bankHtml = '
 <p style="background:#f0f7ee;padding:12px 16px;border-radius:6px;font-size:13px;line-height:1.9;margin:0 0 16px;">
   ' . $bn . 'IBAN: ' . $esc($issuer['iban']) . '<br>' . $bic . '
   Verwendungszweck: Rechnung ' . $esc($invNum) . ' &ndash; ' . $guestName . '
 </p>';
-    }
+        }
 
-    // PayPal button
-    $ppBtn = '';
-    if (defined('PAYPAL_ME_URL') && PAYPAL_ME_URL !== '') {
-        $ppAmount = number_format((float)($totals['total'] ?? 0), 2, '.', '');
-        $ppUrl    = $esc(rtrim(PAYPAL_ME_URL, '/') . '/' . $ppAmount);
-        $ppBtn    = '
+        if (defined('PAYPAL_ME_URL') && PAYPAL_ME_URL !== '') {
+            $ppAmount = number_format((float)($totals['total'] ?? 0), 2, '.', '');
+            $ppUrl    = $esc(rtrim(PAYPAL_ME_URL, '/') . '/' . $ppAmount);
+            $ppBtn    = '
 <p style="text-align:center;margin:0 0 4px;font-size:13px;color:#555;">Oder bequem online bezahlen:</p>
 <p style="text-align:center;margin:0 0 20px;">
   <a href="' . $ppUrl . '" style="display:inline-block;background:#0070ba;color:#fff;padding:11px 28px;border-radius:6px;text-decoration:none;font-weight:700;font-size:14px;">Mit PayPal bezahlen</a>
 </p>';
-    }
+        }
 
-    // Cancellation warning
-    $cancelNote = '
+        $cancelNote = '
 <p style="background:#fff3cd;border-left:4px solid #e6a817;padding:10px 14px;border-radius:4px;font-size:13px;line-height:1.6;margin:0 0 20px;">
   <strong>Wichtiger Hinweis:</strong> Sollte die Zahlung nicht innerhalb von 7 Tagen eingehen,
   behalten wir uns vor, die Buchung automatisch zu stornieren.
 </p>';
+    }
 
     // Sign-off
     $signOff = '
@@ -249,11 +258,11 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes): bool {
   </table>
 
   <p style="line-height:1.7;margin:0 0 12px;">
-    Im Anhang finden Sie Ihre Rechnung Nr. <strong>' . $esc($invNum) . '</strong>.
-    Bitte begleichen Sie den Betrag innerhalb von <strong>7 Tagen</strong>:
+    Im Anhang finden Sie Ihre Rechnung Nr. <strong>' . $esc($invNum) . '</strong>.' . ($isPaid ? '' : '
+    Bitte begleichen Sie den Betrag innerhalb von <strong>7 Tagen</strong>:') . '
   </p>
 
-  ' . $bankHtml . $ppBtn . $cancelNote . '
+  ' . $paidNote . $bankHtml . $ppBtn . $cancelNote . '
 
   <p style="font-size:13px;color:#555;margin:0 0 20px;line-height:1.7;">
     Bei Fragen erreichen Sie uns unter
@@ -276,8 +285,8 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes): bool {
     <tr style="border-top:1px solid #ede9e1;"><td style="padding:10px 14px;color:#666;">Zeitraum</td><td style="padding:10px 14px;">' . $checkIn . ' – ' . $checkOut . '</td></tr>
     <tr style="border-top:1px solid #ede9e1;background:#f0f7ee;"><td style="padding:10px 14px;color:#666;">Gesamtbetrag</td><td style="padding:10px 14px;font-weight:700;color:#3d5a3e;">' . $total . '</td></tr>
   </table>
-  <p style="line-height:1.7;margin:0 0 12px;">Bitte begleichen Sie den Betrag innerhalb von <strong>7 Tagen</strong>:</p>
-  ' . $bankHtml . $ppBtn . $cancelNote . $signOff . '
+  ' . ($isPaid ? '' : '<p style="line-height:1.7;margin:0 0 12px;">Bitte begleichen Sie den Betrag innerhalb von <strong>7 Tagen</strong>:</p>') . '
+  ' . $paidNote . $bankHtml . $ppBtn . $cancelNote . $signOff . '
 </div>';
     }
 

--- a/server/invoice-review.php
+++ b/server/invoice-review.php
@@ -54,31 +54,65 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && $status === 'pending') {
     $note   = trim($_POST['note'] ?? '');
 
     if ($action === 'approve') {
-        $draft['note']        = $note;
-        $draft['invoiceDate'] = date('Y-m-d');
-        $draft['approvedAt']  = date('c');
-        $draft['status']      = 'approved';
+        $requestedNumber = trim($_POST['invoice_number'] ?? '') ?: peekNextInvoiceNumber();
 
-        // Generate PDF
-        $pdfBytes = generateInvoicePdf($draft);
+        if (!tryAssignInvoiceNumber($draft, $requestedNumber, $draftPath)) {
+            $flash = 'err:Rechnungsnummer ' . htmlspecialchars($requestedNumber) . ' ist ungültig oder wird bereits verwendet. Bitte eine andere Nummer wählen.';
+        } else {
+            // Apply guest-data edits
+            $draft['guest']['name']    = trim($_POST['guest_name']    ?? '') ?: ($draft['guest']['name'] ?? 'Unbekannt');
+            $draft['guest']['email']   = trim($_POST['guest_email']   ?? ($draft['guest']['email']   ?? ''));
+            $draft['guest']['address'] = trim($_POST['guest_address'] ?? ($draft['guest']['address'] ?? ''));
+            $draft['guest']['zip']     = trim($_POST['guest_zip']     ?? ($draft['guest']['zip']     ?? ''));
+            $draft['guest']['city']    = trim($_POST['guest_city']    ?? ($draft['guest']['city']    ?? ''));
 
-        // Save PDF file
-        $sentDir = __DIR__ . '/invoices/sent';
-        if (!is_dir($sentDir)) mkdir($sentDir, 0750, true);
-        file_put_contents($pdfPath, $pdfBytes);
+            // Apply line-item edits — blank description rows (the spare ones) are dropped
+            $editedItems = [];
+            foreach (($_POST['item_desc'] ?? []) as $i => $desc) {
+                $desc = trim((string)$desc);
+                if ($desc === '') continue;
+                $qty   = (float)($_POST['item_qty'][$i]  ?? 1);
+                $unit  = (float)str_replace(',', '.', (string)($_POST['item_unit'][$i] ?? 0));
+                $vat   = (int)($_POST['item_vat'][$i] ?? 7);
+                $gross = round($qty * $unit, 2);
+                if (abs($gross) < 0.01) continue;
+                $editedItems[] = makeLineItem($desc, $gross, $vat, $qty, $unit);
+            }
+            if (!empty($editedItems)) {
+                $draft['lineItems'] = $editedItems;
+                $draft['totals']    = calcTotals($editedItems);
+            }
 
-        // Email guest
-        $emailSent = sendInvoiceToGuest($draft, $pdfBytes);
-        $draft['guestEmailSent'] = $emailSent;
+            $draft['paymentNote'] = trim($_POST['payment_note'] ?? '') ?: ($draft['paymentNote'] ?? '');
+            $draft['note']        = $note;
+            $draft['invoiceDate'] = date('Y-m-d');
+            $draft['approvedAt']  = date('c');
+            $draft['status']      = 'approved';
 
-        // Persist
-        file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
-        draftLog((int)($draft['bookingId'] ?? 0), 'approved', "token={$token} emailSent=" . ($emailSent ? '1' : '0'));
+            $isPaid = ($_POST['already_paid'] ?? '') === '1';
+            $draft['manuallyMarkedPaid'] = $isPaid;
 
-        $status = 'approved';
-        $flash  = $emailSent
-            ? 'ok:Rechnung genehmigt und an ' . htmlspecialchars($draft['guest']['email'] ?? '') . ' gesendet.'
-            : 'ok:Rechnung genehmigt. Kein E-Mail-Versand — Gast hat keine E-Mail-Adresse hinterlegt.';
+            // Generate PDF
+            $pdfBytes = generateInvoicePdf($draft);
+
+            // Save PDF file
+            $sentDir = __DIR__ . '/invoices/sent';
+            if (!is_dir($sentDir)) mkdir($sentDir, 0750, true);
+            file_put_contents($pdfPath, $pdfBytes);
+
+            // Email guest (Steuerbüro receives a BCC copy automatically)
+            $emailSent = sendInvoiceToGuest($draft, $pdfBytes, $isPaid);
+            $draft['guestEmailSent'] = $emailSent;
+
+            // Persist
+            file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+            draftLog((int)($draft['bookingId'] ?? 0), 'approved', "token={$token} invoiceNumber={$draft['invoiceNumber']} emailSent=" . ($emailSent ? '1' : '0') . ' paid=' . ($isPaid ? '1' : '0'));
+
+            $status = 'approved';
+            $flash  = $emailSent
+                ? 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' genehmigt und an ' . htmlspecialchars($draft['guest']['email'] ?? '') . ' gesendet.'
+                : 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' genehmigt. Kein E-Mail-Versand — Gast hat keine E-Mail-Adresse hinterlegt.';
+        }
 
     } elseif ($action === 'reject') {
         $draft['note']       = $note;
@@ -103,12 +137,22 @@ $checkIn  = $stay['checkIn']  ? date('d.m.Y', strtotime($stay['checkIn']))  : '�
 $checkOut = $stay['checkOut'] ? date('d.m.Y', strtotime($stay['checkOut'])) : '–';
 $total    = number_format((float)($totals['total'] ?? 0), 2, ',', '.');
 
+// Recompute — invoiceNumber may have just been assigned above (approve), or
+// may still be unset (pending), in which case show a live suggestion.
+$invNum = $draft['invoiceNumber'] ?? ($status === 'pending' ? peekNextInvoiceNumber() : '');
+
 $statusLabels = ['pending' => 'Ausstehend', 'approved' => 'Genehmigt', 'rejected' => 'Abgelehnt'];
 $statusColors = ['pending' => '#e67e22',    'approved' => '#27ae60',   'rejected' => '#c0392b'];
 $statusLabel  = $statusLabels[$status] ?? $status;
 $statusColor  = $statusColors[$status] ?? '#888';
 
-$previewHtml = htmlspecialchars(buildInvoiceHtml($draft), ENT_QUOTES, 'UTF-8');
+// Preview needs a non-empty invoice number even before approval — use the
+// same live suggestion shown in the form, without persisting it to the draft.
+$previewDraft = $draft;
+if (empty($previewDraft['invoiceNumber'])) {
+    $previewDraft['invoiceNumber'] = $invNum;
+}
+$previewHtml = htmlspecialchars(buildInvoiceHtml($previewDraft), ENT_QUOTES, 'UTF-8');
 
 [$flashType, $flashMsg] = $flash ? explode(':', $flash, 2) : ['', ''];
 
@@ -139,7 +183,22 @@ table.info td:first-child { color: #777; width: 150px; white-space: nowrap; }
 .btn-red:hover   { background: #a93226; }
 .btn-link  { background: none; border: 1px solid #ccc; color: #555; }
 .btn-link:hover  { border-color: #999; }
-textarea { width: 100%; border: 1px solid #d5d5d5; border-radius: 5px; padding: 9px 11px; font-size: 13px; resize: vertical; font-family: inherit; }
+textarea,
+input[type="text"], input[type="email"], input[type="number"] {
+  width: 100%; border: 1px solid #d5d5d5; border-radius: 5px; padding: 9px 11px;
+  font-size: 13px; resize: vertical; font-family: inherit; margin-bottom: 4px;
+}
+select { border: 1px solid #d5d5d5; border-radius: 5px; padding: 9px 6px; font-size: 13px; font-family: inherit; width: 100%; }
+.field-row { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 4px; }
+.field-row > div { flex: 1; min-width: 140px; }
+.section-title { font-size: 15px; color: #3d5a3e; margin: 22px 0 10px; }
+.section-title:first-child { margin-top: 0; }
+.items-scroll { overflow-x: auto; margin-bottom: 14px; }
+table.items-edit { width: 100%; border-collapse: collapse; min-width: 480px; }
+table.items-edit th { text-align: left; font-size: 11px; color: #888; font-weight: 600; padding: 4px 6px; }
+table.items-edit td { padding: 4px 6px; }
+.checkbox-row { display: flex; align-items: flex-start; gap: 8px; font-weight: 400; margin: 16px 0; font-size: 13px; line-height: 1.5; }
+.checkbox-row input { width: auto; margin-top: 3px; }
 .flash-ok  { background: #eafaf1; border: 1px solid #a9dfbf; color: #1e8449; border-radius: 6px; padding: 13px 16px; margin-bottom: 18px; }
 .flash-err { background: #fdecea; border: 1px solid #f5b7b1; color: #c0392b; border-radius: 6px; padding: 13px 16px; margin-bottom: 18px; }
 .preview iframe { width: 100%; height: 680px; border: none; display: block; border-radius: 0 0 8px 8px; }
@@ -160,7 +219,7 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
   <?php endif; ?>
 
   <div class="card">
-    <h1>Rechnung Nr. <?= htmlspecialchars($invNum) ?> prüfen</h1>
+    <h1>Rechnung Nr. <?= htmlspecialchars($invNum) ?><?= $status === 'pending' ? ' (Vorschlag)' : '' ?> prüfen</h1>
     <p class="meta">
       Buchung #<?= (int)($draft['bookingId'] ?? 0) ?> &nbsp;·&nbsp;
       Erstellt: <?= date('d.m.Y H:i', strtotime($draft['createdAt'] ?? 'now')) ?> &nbsp;·&nbsp;
@@ -173,6 +232,9 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
       <tr><td>Zimmer</td><td><?= htmlspecialchars($stay['roomName'] ?? '–') ?></td></tr>
       <tr><td>Zeitraum</td><td><?= $checkIn ?> – <?= $checkOut ?> &nbsp;(<?= (int)($stay['nights'] ?? 0) ?> Nächte, <?= (int)($stay['adults'] ?? 0) ?> Erw.)</td></tr>
       <tr><td>Gesamtbetrag</td><td><strong><?= $total ?> €</strong></td></tr>
+      <?php if (!empty($draft['prePaid']) && $status === 'pending'): ?>
+      <tr><td>Zahlungsstatus</td><td><span style="color:#27ae60;font-weight:600;">Bereits vollständig bezahlt</span> (laut Beds24 bei Buchungseingang)</td></tr>
+      <?php endif; ?>
       <?php if (!empty($draft['approvedAt'])): ?>
       <tr><td>Genehmigt</td><td><?= date('d.m.Y H:i', strtotime($draft['approvedAt'])) ?></td></tr>
       <?php endif; ?>
@@ -185,8 +247,62 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
   <?php if ($status === 'pending'): ?>
   <div class="card">
     <form method="post">
+      <label for="invoice_number">Rechnungsnummer <span style="font-weight:400;color:#999;">(Vorschlag — bei Bedarf anpassen)</span></label>
+      <input type="text" id="invoice_number" name="invoice_number" value="<?= htmlspecialchars($invNum) ?>" pattern="\d{4}-\d{3,}" required>
+
+      <h2 class="section-title">Gastdaten</h2>
+      <div class="field-row">
+        <div><label for="guest_name">Name</label><input type="text" id="guest_name" name="guest_name" value="<?= htmlspecialchars($guest['name'] ?? '') ?>"></div>
+        <div><label for="guest_email">E-Mail</label><input type="email" id="guest_email" name="guest_email" value="<?= htmlspecialchars($guest['email'] ?? '') ?>"></div>
+      </div>
+      <div class="field-row">
+        <div><label for="guest_address">Straße</label><input type="text" id="guest_address" name="guest_address" value="<?= htmlspecialchars($guest['address'] ?? '') ?>"></div>
+        <div><label for="guest_zip">PLZ</label><input type="text" id="guest_zip" name="guest_zip" value="<?= htmlspecialchars($guest['zip'] ?? '') ?>"></div>
+        <div><label for="guest_city">Ort</label><input type="text" id="guest_city" name="guest_city" value="<?= htmlspecialchars($guest['city'] ?? '') ?>"></div>
+      </div>
+
+      <h2 class="section-title">Positionen</h2>
+      <div class="items-scroll">
+        <table class="items-edit">
+          <thead>
+            <tr><th>Beschreibung</th><th>Anzahl</th><th>Einzelpreis brutto</th><th>MwSt.</th></tr>
+          </thead>
+          <tbody>
+            <?php
+              $editRows = $draft['lineItems'];
+              for ($blank = 0; $blank < 2; $blank++) {
+                  $editRows[] = ['description' => '', 'qty' => 1, 'unitGross' => '', 'vatRate' => 7];
+              }
+              foreach ($editRows as $item):
+                  $vatRate = (int)($item['vatRate'] ?? 7);
+            ?>
+            <tr>
+              <td><input type="text" name="item_desc[]" value="<?= htmlspecialchars($item['description'] ?? '') ?>"></td>
+              <td><input type="number" step="0.5" min="0" name="item_qty[]" value="<?= htmlspecialchars((string)($item['qty'] ?? 1)) ?>"></td>
+              <td><input type="number" step="0.01" min="0" name="item_unit[]" value="<?= htmlspecialchars($item['unitGross'] !== '' ? (string)$item['unitGross'] : '') ?>"></td>
+              <td>
+                <select name="item_vat[]">
+                  <option value="7"  <?= $vatRate === 7  ? 'selected' : '' ?>>7%</option>
+                  <option value="19" <?= $vatRate === 19 ? 'selected' : '' ?>>19%</option>
+                </select>
+              </td>
+            </tr>
+            <?php endforeach; ?>
+          </tbody>
+        </table>
+      </div>
+
+      <label for="payment_note">Zahlungshinweis</label>
+      <input type="text" id="payment_note" name="payment_note" value="<?= htmlspecialchars($draft['paymentNote'] ?? '') ?>">
+
       <label for="note">Hinweis / Notiz <span style="font-weight:400;color:#999;">(optional — erscheint auf der Rechnung)</span></label>
       <textarea id="note" name="note" rows="2" placeholder="z.B. Rabatt, Sondervereinbarung ..."><?= htmlspecialchars($draft['note'] ?? '') ?></textarea>
+
+      <label class="checkbox-row">
+        <input type="checkbox" name="already_paid" value="1" <?= !empty($draft['prePaid']) ? 'checked' : '' ?>>
+        Bereits bezahlt (z.&nbsp;B. bar/Karte vor Ort) — Gast erhält eine Zahlungsbestätigung statt einer Zahlungsaufforderung
+      </label>
+
       <div class="actions">
         <button type="submit" name="action" value="approve" class="btn btn-green">✓ Genehmigen &amp; an Gast senden</button>
         <button type="submit" name="action" value="reject"  class="btn btn-red"


### PR DESCRIPTION
## Summary

Builds out the automated Beds24-triggered invoicing workflow so nothing ever reaches a guest without Simone reviewing it first - even bookings paid in full up front.

- Review page (`invoice-review.php`) gets fully editable Gastdaten, Positionen (with the specific room name on the accommodation line), Zahlungshinweis, and Rechnungsnummer, plus a "bereits bezahlt" toggle.
- Every guest invoice email now BCCs the Steuerbuero automatically alongside kontakt@ (`STEUERBUERO_EMAIL` in config).
- Invoice numbers are now assigned at approval time instead of draft creation (so a rejected draft never burns a number), validated and reserved atomically under a fixed counter lock (the old lock silently proceeded without exclusivity after failed retries).
- Removed the auto-send bypass for already-paid bookings - a wrong invoice number is exactly the mistake a payment-only check would miss, so every draft goes through review now regardless of payment status.
- Fruehstueck is now split into "Speisen" (7%) / "Getraenke" (19%) line items per German VAT rules, matched against a fixed price-tier table (`BREAKFAST_TIERS`) since Beds24 only ever sends one combined breakfast amount.

**Note:** this branch was cut from `fix/reporting-blind-bookings-breakfast` (not `main`), which is itself not yet merged - so this diff also includes that branch's reporting-fix commits (`f9299a7`, `35742c8`, `7caaa3b`, `f5c86d9`), not just the two invoicing commits on top.

## Test plan

- [x] All changes deployed live to `api.pension-volgenandt.de` and verified against synthetic + one real draft (editable fields, room-name labeling, invoice-number suggestion/validation, prePaid pre-check all render correctly)
- [ ] Watch the first real invoice approval this week - the approve-and-assign path (PDF gen, invoice number commit, guest+Steuerbuero email) was only code-reviewed, never live-exercised with real data
- [ ] Watch the first real breakfast-inclusive booking - the Speisen/Getraenke split was traced by hand but not live-exercised
- [ ] Confirm with the Steuerbuero that the BCC'd emails are arriving and processing correctly

Generated with Claude Code