### PR TITLE
content: remove AI-style dashes/clichés sitewide, add Wespen article

### DIFF
--- a/app/components/events/EventPlanner.vue
+++ b/app/components/events/EventPlanner.vue
@@ -109,7 +109,7 @@ const optionSteps = computed<WizardStep[]>(() => [
     image: '/img/picknick/garten-pavillon-sitzecke.webp',
     imageAlt: 'Gemütliche Sitzecke im Garten',
     intro:
-      'Die Getränke laufen über uns – wählen Sie zwischen Selbstbedienung und Service am Tisch. Abgerechnet pro Person und Stunde, richtet sich also nach Gästezahl und Dauer Ihrer Feier.',
+      'Die Getränke laufen über uns: Wählen Sie zwischen Selbstbedienung und Service am Tisch. Abgerechnet pro Person und Stunde, richtet sich also nach Gästezahl und Dauer Ihrer Feier.',
     groups: [
       {
         key: 'drinkId',
@@ -125,7 +125,7 @@ const optionSteps = computed<WizardStep[]>(() => [
     image: '/img/garten/garten-sitzbank-apfelbaum-bluete.webp',
     imageAlt: 'Blühender Apfelbaum mit Sitzbank im Garten',
     intro:
-      'Möchten Sie direkt bei uns im Garten heiraten? Ein professioneller Trauredner gestaltet Ihre freie Zeremonie – Trauung und Feier an einem Ort, ganz ohne Fahrt dazwischen. Für alle anderen Anlässe lassen Sie diese Auswahl einfach bei „Keine Trauung“.',
+      'Möchten Sie direkt bei uns im Garten heiraten? Ein professioneller Trauredner gestaltet Ihre freie Zeremonie: Trauung und Feier finden an einem Ort statt, ganz ohne Fahrt dazwischen. Für alle anderen Anlässe lassen Sie diese Auswahl einfach bei „Keine Trauung“.',
     groups: [
       {
         key: 'ceremonyId',
@@ -193,7 +193,7 @@ const optionSteps = computed<WizardStep[]>(() => [
     image: '/img/picknick/garten-sitzecke-rosen.webp',
     imageAlt: 'Sitzecke mit Rosen im Garten',
     intro:
-      'Der Unterhaltungs-Hit für Ihre Gäste: eine Fotobox mit Requisiten und Sofortdruck – für viele Lacher und ein Gästebuch voller Erinnerungen.',
+      'Der Unterhaltungs-Hit für Ihre Gäste: eine Fotobox mit Requisiten und Sofortdruck, für viele Lacher und ein Gästebuch voller Erinnerungen.',
     groups: [
       { key: 'photoboothId', unit: 'flat', legend: 'Fotobox', options: opts('photoboothOptions') },
     ],
@@ -213,7 +213,7 @@ const optionSteps = computed<WizardStep[]>(() => [
     image: '/img/garten/garten-sitzecke-apfelbaum.webp',
     imageAlt: 'Sitzgelegenheit unter dem Apfelbaum',
     intro:
-      'Vom rustikalen bis zum eleganten Look: Stellen Sie Tische, Stuhlhussen, Geschirr und Bodenbelag zusammen. Die jeweils erste Option ist bereits im Basispreis enthalten – jede Aufwertung wird pro Person berechnet.',
+      'Vom rustikalen bis zum eleganten Look: Stellen Sie Tische, Stuhlhussen, Geschirr und Bodenbelag zusammen. Die jeweils erste Option ist bereits im Basispreis enthalten. Jede Aufwertung wird pro Person berechnet.',
     groups: [
       { key: 'tableId', unit: 'person', legend: 'Tische', options: opts('tableOptions') },
       {
@@ -540,7 +540,7 @@ const inputClass =
           <div>
             <p class="text-sage-700">
               Beantworten Sie zunächst ein paar kurze Fragen. Danach führen wir Sie Schritt für
-              Schritt durch alle Möglichkeiten – Sie sehen bei jeder Auswahl sofort, was sie für
+              Schritt durch alle Möglichkeiten. Bei jeder Auswahl sehen Sie sofort, was sie für
               Ihre Feier bedeutet und was sie kostet.
             </p>
 
@@ -717,7 +717,7 @@ const inputClass =
               Ihre Kontaktdaten
             </legend>
             <p class="text-sm text-sage-600">
-              Senden Sie uns Ihre Zusammenstellung – wir melden uns innerhalb von 24 Stunden mit
+              Senden Sie uns Ihre Zusammenstellung. Wir melden uns innerhalb von 24 Stunden mit
               einem persönlichen, unverbindlichen Angebot.
             </p>
             <div class="grid gap-5 sm:grid-cols-2">

--- a/app/components/home/PicknickPromo.vue
+++ b/app/components/home/PicknickPromo.vue
@@ -99,7 +99,7 @@ function dismiss() {
           </div>
 
           <p class="mt-3 text-sm leading-relaxed text-sage-600">
-            Im Garten der Pension entspannen oder auf einen Ausflug ins Eichsfeld mitnehmen – wir
+            Im Garten der Pension entspannen oder auf einen Ausflug ins Eichsfeld mitnehmen: Wir
             packen alles ein. Ausflugstipps gibt es auf unserer Website.
           </p>
 
@@ -113,7 +113,7 @@ function dismiss() {
               class="shrink-0 text-waldhonig-500"
               aria-hidden="true"
             />
-            <span>Auch ohne Zimmerbuchung – <strong>Tagesgäste herzlich willkommen.</strong></span>
+            <span>Auch ohne Zimmerbuchung sind <strong>Tagesgäste herzlich willkommen.</strong></span>
           </div>
 
           <NuxtLink

--- a/app/components/picknick/BookingForm.vue
+++ b/app/components/picknick/BookingForm.vue
@@ -535,7 +535,7 @@ if (import.meta.client) {
       </div>
 
       <p v-if="isBrunch" class="text-xs text-sage-500">
-        Frische Brötchen sind enthalten – ein Croissant ist optional zubuchbar.
+        Frische Brötchen sind enthalten. Ein Croissant ist optional zubuchbar.
       </p>
       <p v-else class="text-xs text-sage-500">
         Brezeln (2 pro Person) sind im Abendschmaus bereits enthalten.
@@ -598,7 +598,7 @@ if (import.meta.client) {
         Kind)
       </h3>
       <p class="mt-1 text-xs text-sage-500">
-        Eigens für unsere kleinen Gäste zusammengestellt – mit kleiner Überraschung
+        Eigens für unsere kleinen Gäste zusammengestellt, inklusive kleiner Überraschung
       </p>
       <ul class="mt-3 space-y-1.5">
         <li

--- a/app/i18n/locales/de.json
+++ b/app/i18n/locales/de.json
@@ -53,7 +53,7 @@
   },
   "rooms": {
     "title": "Unsere Zimmer",
-    "subtitle": "Ob gemütliche Ferienwohnung für die ganze Familie oder komfortables Doppelzimmer für Paare – bei uns finden Sie den passenden Rückzugsort für Ihren Aufenthalt im Eichsfeld.",
+    "subtitle": "Wir haben gemütliche Ferienwohnungen für Familien und komfortable Doppelzimmer für Paare. Bei uns finden Sie den passenden Rückzugsort für Ihren Aufenthalt im Eichsfeld.",
     "chooseRoom": "Wählen Sie ein Zimmer, um Verfügbarkeit und Buchungsmöglichkeiten zu sehen."
   },
   "price": {
@@ -76,14 +76,14 @@
     "heading": "Kontakt & Anfahrt",
     "subtitle": "Wir freuen uns auf Sie",
     "talkToUs": "Sprechen Sie uns an",
-    "talkToUsText": "Ob Sie eine Frage haben, ein Zimmer buchen möchten oder einfach mehr über unsere Pension erfahren wollen – wir sind gerne für Sie da.",
+    "talkToUsText": "Egal ob Sie eine Frage haben, ein Zimmer buchen möchten oder mehr über unsere Pension erfahren wollen: Wir sind gerne für Sie da.",
     "mobile": "Mobil",
     "whatsapp": "WhatsApp",
     "landline": "Festnetz",
     "email": "E-Mail",
     "address": "Adresse",
     "sendMessage": "Nachricht senden",
-    "sendMessageText": "Schreiben Sie uns – wir antworten in der Regel innerhalb von 24 Stunden."
+    "sendMessageText": "Schreiben Sie uns, wir antworten in der Regel innerhalb von 24 Stunden."
   },
   "form": {
     "name": "Name",
@@ -101,7 +101,7 @@
     "byCar": "Mit dem Auto (A38)",
     "byCarText": "Von der A38 nehmen Sie die Ausfahrt Leinefelde und folgen der Beschilderung Richtung Breitenbach. Nach etwa 10 Minuten Fahrt erreichen Sie unsere Pension an der Otto-Reutter-Straße 28. Kostenlose Parkplätze stehen direkt vor dem Haus bereit.",
     "byTrain": "Mit der Bahn",
-    "byTrainText": "Vom Bahnhof Leinefelde sind es 4 km bis zu unserer Pension. Gerne holen wir Sie nach Absprache vom Bahnhof ab – rufen Sie uns einfach vorher an.",
+    "byTrainText": "Vom Bahnhof Leinefelde sind es 4 km bis zu unserer Pension. Gerne holen wir Sie nach Absprache vom Bahnhof ab. Rufen Sie uns dafür einfach vorher an.",
     "gps": "Koordinaten für das Navi",
     "openMaps": "In Google Maps öffnen"
   },
@@ -144,13 +144,13 @@
     "heroButton": "Zimmer entdecken",
     "welcomeHeading": "Willkommen in Breitenbach",
     "welcomeText": "",
-    "welcomeTitle": "Willkommen bei uns",
-    "welcomeParagraph1": "Wir sind Simone & Ralf Volgenandt und freuen uns, Sie in unserem Zuhause im Eichsfeld willkommen zu heißen. Unsere Pension liegt etwa einen Kilometer außerhalb von Breitenbach, eingebettet in die sanfte Hügellandschaft Thüringens – ein Ort, an dem die Zeit ein wenig langsamer vergeht.",
+    "welcomeTitle": "Unser Zuhause im Eichsfeld",
+    "welcomeParagraph1": "Wir sind Simone & Ralf Volgenandt und freuen uns, Sie in unserem Zuhause im Eichsfeld willkommen zu heißen. Unsere Pension liegt etwa einen Kilometer außerhalb von Breitenbach, eingebettet in die sanfte Hügellandschaft Thüringens, wo die Zeit ein wenig langsamer vergeht.",
     "welcomeParagraph2": "Ob Sie die Burgen und Wanderwege der Region erkunden, den nahen Bärenpark besuchen oder einfach die Stille genießen möchten: Bei uns finden Sie den Ausgangspunkt für erholsame Tage. Unsere Ferienwohnungen und Zimmer bieten Ihnen Platz, Komfort und einen Blick ins Grüne.",
-    "welcomeParagraph3": "Wir bewirtschaften unser Haus mit Sorgfalt und Liebe zur Natur – mit Solarenergie vom eigenen Dach, einer biologischen Kläranlage und einem Garten, der zum Verweilen einlädt.",
-    "welcomeImageAlt": "Simone und Ralf Volgenandt – Ihre Gastgeber in Breitenbach",
+    "welcomeParagraph3": "Wir bewirtschaften unser Haus mit Sorgfalt und Liebe zur Natur: mit Solarenergie vom eigenen Dach, einer biologischen Kläranlage und einem Garten, der zum Verweilen einlädt.",
+    "welcomeImageAlt": "Simone und Ralf Volgenandt, Ihre Gastgeber in Breitenbach",
     "gardenHeading": "Garten & Umgebung",
-    "gardenSubtitle": "Vier Jahreszeiten – ein Ort der Ruhe",
+    "gardenSubtitle": "Zu jeder Jahreszeit ein Ort der Ruhe",
     "ourRooms": "Unsere Zimmer",
     "testimonialsHeading": "Was unsere Gäste sagen",
     "googleReview": "Google Bewertung",
@@ -159,7 +159,7 @@
     "ariaPrevQuote": "Vorheriges Zitat",
     "ariaNextQuote": "Nächstes Zitat",
     "ariaQuoteOf": "Zitat {current} von {total}",
-    "experienceHeading": "Erleben Sie das Eichsfeld",
+    "experienceHeading": "Das Eichsfeld entdecken",
     "exploreAttractions": "Alle Ausflugsziele entdecken",
     "sustainabilityHeading": "Natürlich nachhaltig",
     "sustainabilityText": "Nachhaltigkeit ist bei uns kein Trend, sondern gelebter Alltag. Unser Zuhause im Eichsfeld pflegen wir mit derselben Sorgfalt wie Ihren Aufenthalt.",
@@ -185,7 +185,7 @@
     "gardenPhoto9": "Winterlandschaft im Eichsfeld mit verschneiten Feldern und Sonnenschein"
   },
   "hosts": {
-    "caption": "Simone & Ralf Volgenandt – wir freuen uns auf Sie",
+    "caption": "Simone & Ralf Volgenandt, wir freuen uns auf Sie",
     "buildingCaption": "So empfängt Sie unsere Pension"
   },
   "softCta": {
@@ -217,14 +217,14 @@
       "region": "Region",
       "pension": "Pension"
     },
-    "eventQuestion": "Haben Sie Fragen zu dieser Veranstaltung? Wir beraten Sie gerne.",
+    "articleQuestion": "Haben Sie Fragen dazu? Wir beraten Sie gerne.",
     "stayWithUs": "Übernachten Sie bei uns im Eichsfeld"
   },
   "activities": {
     "title": "Aktivitäten",
     "subtitle": "Entdecken Sie das Eichsfeld",
     "intro1": "Das Eichsfeld ist ein Paradies für alle, die gerne draußen unterwegs sind. In der Umgebung unserer Pension finden Sie zahlreiche Wander- und Radwege, die durch eine der schönsten Landschaften Thüringens führen.",
-    "intro2": "Ob sportlich oder gemütlich, allein oder mit der Familie – wir beraten Sie gerne zu den besten Routen und Ausflugszielen in unserer Nähe.",
+    "intro2": "Ob sportlich oder gemütlich, allein oder mit der Familie: Wir beraten Sie gerne zu den besten Routen und Ausflugszielen in unserer Nähe.",
     "popularAttractions": "Beliebte Ausflugsziele",
     "sportingActivities": "Sportliche Aktivitäten",
     "planActive": "Planen Sie Ihren aktiven Urlaub im Eichsfeld",
@@ -234,10 +234,10 @@
     },
     "cycling": {
       "title": "Radfahren",
-      "description": "Ob gemütliche Radtour entlang der Leine oder sportliche Route durch die Hügel – hier ist für jeden etwas dabei."
+      "description": "Ob gemütliche Radtour entlang der Leine oder sportliche Route durch die Hügel: Hier ist für jeden etwas dabei."
     },
-    "picnicHeading": "Picknick-Korb – Der Ausflug mit Genuss",
-    "picnicText": "Nehmen Sie unseren hausgemachten Picknick-Korb auf Ihre Tour mit – ob zur Burg Hanstein, an den Seeburger See oder einfach in den Garten. Regional, saisonal, mit echtem Geschirr. Ab 19 € pro Person.",
+    "picnicHeading": "Unser Picknick-Korb für unterwegs",
+    "picnicText": "Nehmen Sie unseren hausgemachten Picknick-Korb auf Ihre Tour mit, ob zur Burg Hanstein, an den Seeburger See oder einfach in den Garten. Regional, saisonal, mit echtem Geschirr. Ab 19 € pro Person.",
     "picnicLink": "Picknick-Korb entdecken"
   },
   "attractions": {
@@ -248,7 +248,7 @@
     "recommendations": "Unsere Empfehlungen",
     "activitiesHeading": "Aktivitäten",
     "returnToRooms": "Nach einem erlebnisreichen Tag zurück in gemütliche Zimmer",
-    "hikingDesc": "Wanderwege in der Umgebung – von gemütlich bis anspruchsvoll.",
+    "hikingDesc": "Wanderwege in der Umgebung, von gemütlich bis anspruchsvoll.",
     "cyclingDesc": "Der Leine-Radweg führt direkt an Breitenbach vorbei."
   },
   "activity": {
@@ -314,8 +314,8 @@
     "bookNow": "Jetzt Zimmer sichern",
     "moreInfo": "Mehr erfahren",
     "countdownLabel": "Tage noch",
-    "teaserTitle": "Landesgartenschau 2026 – direkt vor unserer Tür",
-    "teaserText": "Vom 23. April bis 11. Oktober verwandelt sich Leinefelde-Worbis in einen blühenden Veranstaltungsort – nur 5 Autominuten von unserer Pension. Über 300.000 Besucher werden erwartet. Sichern Sie sich rechtzeitig Ihr Zimmer."
+    "teaserTitle": "Landesgartenschau 2026 direkt vor unserer Tür",
+    "teaserText": "Vom 23. April bis 11. Oktober verwandelt sich Leinefelde-Worbis in einen blühenden Veranstaltungsort, nur 5 Autominuten von unserer Pension. Über 300.000 Besucher werden erwartet. Sichern Sie sich rechtzeitig Ihr Zimmer."
   },
   "ferienwohnungen": {
     "title": "Ferienwohnungen im Eichsfeld",
@@ -331,7 +331,7 @@
   "monteurzimmer": {
     "title": "Monteurzimmer in Leinefelde-Worbis",
     "subtitle": "Günstig, komfortabel & verkehrsgünstig gelegen",
-    "intro": "Sie arbeiten in Leinefelde-Worbis oder im Eichsfeld? Unsere Pension bietet komfortable Zimmer für Monteure, Handwerker und Geschäftsreisende – mit kostenlosem WLAN, Parkplatz und Küchenzugang.",
+    "intro": "Sie arbeiten in Leinefelde-Worbis oder im Eichsfeld? Unsere Pension bietet komfortable Zimmer für Monteure, Handwerker und Geschäftsreisende, inklusive kostenlosem WLAN, Parkplatz und Küchenzugang.",
     "highlights": "Ihre Vorteile",
     "wifi": "Kostenloses WLAN",
     "parking": "Kostenloser Parkplatz",
@@ -339,6 +339,8 @@
     "location": "Nahe A38 & Leinefelde",
     "quiet": "Ruhige Lage im Grünen",
     "weekly": "Attraktive Wochenpreise auf Anfrage",
+    "forWorkersTitle": "Für längere Einsätze",
+    "forWorkersText": "Als familiengeführte Pension sind wir auf längere Aufenthalte eingestellt, wie sie bei Bauprojekten oder Montageeinsätzen im Eichsfeld üblich sind. Auf Wunsch stellen wir die Rechnung direkt auf Ihre Firmenadresse aus. Bei Fragen zu Ihrem Aufenthalt erreichen Sie uns direkt und unkompliziert, telefonisch oder per E-Mail.",
     "bookNow": "Zimmer anfragen"
   }
 }

--- a/app/i18n/locales/en.json
+++ b/app/i18n/locales/en.json
@@ -53,7 +53,7 @@
   },
   "rooms": {
     "title": "Our Rooms",
-    "subtitle": "Whether a cosy holiday apartment for the whole family or a comfortable double room for couples – you will find the perfect retreat for your stay in the Eichsfeld.",
+    "subtitle": "We offer cosy holiday apartments for families and comfortable double rooms for couples, so you will find the perfect retreat for your stay in the Eichsfeld.",
     "chooseRoom": "Select a room to see availability and booking options."
   },
   "price": {
@@ -76,14 +76,14 @@
     "heading": "Contact & Directions",
     "subtitle": "We look forward to hearing from you",
     "talkToUs": "Get in touch",
-    "talkToUsText": "Whether you have a question, would like to book a room, or simply want to learn more about our guesthouse – we are happy to help.",
+    "talkToUsText": "Whether you have a question, would like to book a room, or simply want to learn more about our guesthouse, we are happy to help.",
     "mobile": "Mobile",
     "whatsapp": "WhatsApp",
     "landline": "Landline",
     "email": "Email",
     "address": "Address",
     "sendMessage": "Send a message",
-    "sendMessageText": "Write to us – we usually reply within 24 hours."
+    "sendMessageText": "Write to us and we usually reply within 24 hours."
   },
   "form": {
     "name": "Name",
@@ -101,7 +101,7 @@
     "byCar": "By car (A38)",
     "byCarText": "From the A38 motorway, take the Leinefelde exit and follow signs towards Breitenbach. After about 10 minutes you will reach our guesthouse at Otto-Reutter-Straße 28. Free parking is available right in front of the building.",
     "byTrain": "By train",
-    "byTrainText": "Leinefelde station is 4 km from our guesthouse. We are happy to pick you up by arrangement – just give us a call beforehand.",
+    "byTrainText": "Leinefelde station is 4 km from our guesthouse. We are happy to pick you up by arrangement. Just give us a call beforehand.",
     "gps": "GPS coordinates",
     "openMaps": "Open in Google Maps"
   },
@@ -143,14 +143,14 @@
     "description": "Family-run guesthouse in Breitenbach, Eichsfeld. Holiday apartments and rooms with views of the countryside.",
     "heroButton": "Discover rooms",
     "welcomeHeading": "Welcome to Breitenbach",
-    "welcomeText": "Our family-run guesthouse in the heart of the Eichsfeld region offers the perfect base for a relaxing getaway. Surrounded by rolling hills, castles, and nature, you can unwind in our comfortable rooms and apartments – each with its own character and views of the countryside.",
-    "welcomeTitle": "Welcome to Our Home",
-    "welcomeParagraph1": "We are Simone & Ralf Volgenandt and we are delighted to welcome you to our home in the Eichsfeld region. Our guesthouse is located about one kilometre outside Breitenbach, nestled in the gentle hills of Thuringia – a place where time passes a little more slowly.",
+    "welcomeText": "Our family-run guesthouse sits in the heart of the Eichsfeld region, surrounded by rolling hills, castles, and nature. Our rooms and apartments are comfortable, each with its own character, and look out over the countryside.",
+    "welcomeTitle": "Our Home in the Eichsfeld",
+    "welcomeParagraph1": "We are Simone & Ralf Volgenandt and we are delighted to welcome you to our home in the Eichsfeld region. Our guesthouse is located about one kilometre outside Breitenbach, nestled in the gentle hills of Thuringia, where time passes a little more slowly.",
     "welcomeParagraph2": "Whether you want to explore the castles and hiking trails of the region, visit the nearby bear park, or simply enjoy the peace and quiet: our guesthouse is the perfect starting point for relaxing days. Our holiday apartments and rooms offer space, comfort, and views of the countryside.",
-    "welcomeParagraph3": "We run our home with care and a love for nature – with solar energy from our own roof, a biological sewage treatment plant, and a garden that invites you to linger.",
-    "welcomeImageAlt": "Simone and Ralf Volgenandt – your hosts in Breitenbach",
+    "welcomeParagraph3": "We run our home with care and a love for nature: with solar energy from our own roof, a biological sewage treatment plant, and a garden that invites you to linger.",
+    "welcomeImageAlt": "Simone and Ralf Volgenandt, your hosts in Breitenbach",
     "gardenHeading": "Garden & Surroundings",
-    "gardenSubtitle": "Four Seasons – A Place of Tranquility",
+    "gardenSubtitle": "A Place of Tranquility All Year Round",
     "ourRooms": "Our Rooms",
     "testimonialsHeading": "What Our Guests Say",
     "googleReview": "Google Review",
@@ -159,10 +159,10 @@
     "ariaPrevQuote": "Previous quote",
     "ariaNextQuote": "Next quote",
     "ariaQuoteOf": "Quote {current} of {total}",
-    "experienceHeading": "Experience the Eichsfeld",
+    "experienceHeading": "Discover the Eichsfeld",
     "exploreAttractions": "Explore all attractions",
     "sustainabilityHeading": "Naturally Sustainable",
-    "sustainabilityText": "Sustainability is not a trend for us – it is part of our everyday life. We care for our home in the Eichsfeld with the same attention we give to your stay.",
+    "sustainabilityText": "Sustainability is not a trend for us. It is part of our everyday life. We care for our home in the Eichsfeld with the same attention we give to your stay.",
     "sustainabilityFeature1Title": "Solar Energy",
     "sustainabilityFeature1Desc": "Our own power from the roof",
     "sustainabilityFeature2Title": "Bio Sewage Plant",
@@ -185,7 +185,7 @@
     "gardenPhoto9": "Winter landscape in the Eichsfeld with snow-covered fields and sunshine"
   },
   "hosts": {
-    "caption": "Simone & Ralf Volgenandt – we look forward to welcoming you",
+    "caption": "Simone & Ralf Volgenandt, we look forward to welcoming you",
     "buildingCaption": "This is how our guesthouse welcomes you"
   },
   "softCta": {
@@ -217,14 +217,14 @@
       "region": "Region",
       "pension": "Guesthouse"
     },
-    "eventQuestion": "Have questions about this event? We're happy to help.",
+    "articleQuestion": "Have questions about this? We're happy to help.",
     "stayWithUs": "Stay with us in the Eichsfeld"
   },
   "activities": {
     "title": "Activities",
     "subtitle": "Explore the Eichsfeld",
     "intro1": "The Eichsfeld is a paradise for anyone who loves the outdoors. In the surroundings of our guesthouse you will find numerous hiking and cycling trails leading through one of the most beautiful landscapes in Thuringia.",
-    "intro2": "Whether sporty or leisurely, alone or with the family – we are happy to advise you on the best routes and attractions nearby.",
+    "intro2": "Whether sporty or leisurely, alone or with the family: We are happy to advise you on the best routes and attractions nearby.",
     "popularAttractions": "Popular Attractions",
     "sportingActivities": "Sporting Activities",
     "planActive": "Plan your active holiday in the Eichsfeld",
@@ -234,10 +234,10 @@
     },
     "cycling": {
       "title": "Cycling",
-      "description": "Whether a leisurely ride along the Leine or a sporty route through the hills – there is something for everyone."
+      "description": "Whether a leisurely ride along the Leine or a sporty route through the hills: There is something for everyone."
     },
-    "picnicHeading": "Picnic Basket – Your Outing with a Twist",
-    "picnicText": "Take our homemade picnic basket along on your trip – to Burg Hanstein, Seeburger See, or simply the garden. Local, seasonal, with real crockery. From €19 per person.",
+    "picnicHeading": "Our Picnic Basket to Go",
+    "picnicText": "Take our homemade picnic basket along on your trip, to Burg Hanstein, Seeburger See, or simply the garden. Local, seasonal, with real crockery. From €19 per person.",
     "picnicLink": "Discover Picnic Basket"
   },
   "attractions": {
@@ -248,7 +248,7 @@
     "recommendations": "Our Recommendations",
     "activitiesHeading": "Activities",
     "returnToRooms": "Return to cosy rooms after an eventful day",
-    "hikingDesc": "Hiking trails nearby – from leisurely to challenging.",
+    "hikingDesc": "Hiking trails nearby, from leisurely to challenging.",
     "cyclingDesc": "The Leine Cycle Path passes right by Breitenbach."
   },
   "activity": {
@@ -314,8 +314,8 @@
     "bookNow": "Book a room now",
     "moreInfo": "Learn more",
     "countdownLabel": "days to go",
-    "teaserTitle": "State Garden Show 2026 – right on our doorstep",
-    "teaserText": "From April 23 to October 11, Leinefelde-Worbis transforms into a blooming event venue – just 5 minutes by car from our guesthouse. Over 300,000 visitors expected. Book your room in time."
+    "teaserTitle": "State Garden Show 2026 right on our doorstep",
+    "teaserText": "From April 23 to October 11, Leinefelde-Worbis transforms into a blooming event venue, just 5 minutes by car from our guesthouse. Over 300,000 visitors expected. Book your room in time."
   },
   "ferienwohnungen": {
     "title": "Holiday Apartments in the Eichsfeld",
@@ -331,7 +331,7 @@
   "monteurzimmer": {
     "title": "Worker Accommodation in Leinefelde-Worbis",
     "subtitle": "Affordable, comfortable & conveniently located",
-    "intro": "Working in Leinefelde-Worbis or the Eichsfeld region? Our guesthouse offers comfortable rooms for tradespeople, craftsmen, and business travellers – with free WiFi, parking, and kitchen access.",
+    "intro": "Working in Leinefelde-Worbis or the Eichsfeld region? Our guesthouse offers comfortable rooms for tradespeople, craftsmen, and business travellers, including free WiFi, parking, and kitchen access.",
     "highlights": "Your benefits",
     "wifi": "Free WiFi",
     "parking": "Free parking",
@@ -339,6 +339,8 @@
     "location": "Near A38 & Leinefelde",
     "quiet": "Quiet location in nature",
     "weekly": "Attractive weekly rates on request",
+    "forWorkersTitle": "For longer assignments",
+    "forWorkersText": "As a family-run guesthouse, we are set up for longer stays, as they are common with construction projects or installation work in the Eichsfeld. On request, we invoice directly to your company address. If you have questions about your stay, you can reach us directly by phone or email.",
     "bookNow": "Enquire about rooms"
   }
 }

--- a/app/pages/aktivitaeten/index.vue
+++ b/app/pages/aktivitaeten/index.vue
@@ -75,7 +75,7 @@ function attractionLink(slug: string) {
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Einfahrt mit Gartenblick im Sommer"
+      image-alt="Einfahrt der Pension Volgenandt mit Gartenblick im Sommer"
       :title="t('activities.title', locale)"
       :subtitle="t('activities.subtitle', locale)"
     />

--- a/app/pages/aktuelles/index.vue
+++ b/app/pages/aktuelles/index.vue
@@ -40,7 +40,7 @@ const { data: articles } = await useAsyncData('news', () =>
   <div>
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Einfahrt mit Gartenblick im Sommer"
+      image-alt="Einfahrt der Pension Volgenandt mit Gartenblick im Sommer"
       title="Aktuelles"
       subtitle="Neuigkeiten aus der Region"
     />

--- a/app/pages/ausflugsziele/index.vue
+++ b/app/pages/ausflugsziele/index.vue
@@ -62,7 +62,7 @@ const activityCards = computed(() => [
     <!-- Banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Einfahrt mit Gartenblick im Sommer"
+      image-alt="Einfahrt der Pension Volgenandt mit Gartenblick im Sommer"
       :title="t('attractions.title', locale)"
       :subtitle="t('attractions.subtitle', locale)"
     />
@@ -107,15 +107,15 @@ const activityCards = computed(() => [
           </div>
           <div>
             <h2 class="font-serif text-2xl font-semibold text-sage-900">
-              Picknick-Korb – Ausflug mit Genuss
+              Picknick-Korb: Ausflug mit Genuss
             </h2>
             <p class="mt-3 leading-relaxed text-sage-700">
-              Nehmen Sie unseren hausgemachten Picknick-Korb auf Ihren Ausflug mit – zur Burg
+              Nehmen Sie unseren hausgemachten Picknick-Korb auf Ihren Ausflug mit, zur Burg
               Hanstein, an den Seeburger See oder einfach in unseren Garten. Regional, saisonal, mit
               echtem Geschirr. Ab 19 € pro Person.
             </p>
             <p class="mt-2 text-sm text-sage-500">
-              Auch für Tagesgäste buchbar – kein Zimmer nötig.
+              Auch für Tagesgäste buchbar, kein Zimmer nötig.
             </p>
             <NuxtLink
               to="/picknick/"

--- a/app/pages/en/about.vue
+++ b/app/pages/en/about.vue
@@ -67,7 +67,7 @@ useJsonLd(
     <!-- Hero photo banner -->
     <SharedPageBanner
       image="/img/content/gastgeber-portrait.webp"
-      image-alt="Simone and Ralf Volgenandt – your hosts in Breitenbach"
+      image-alt="Simone and Ralf Volgenandt, your hosts in Breitenbach"
       title="About Us"
       subtitle="Welcome to our home in the Eichsfeld"
     />
@@ -96,14 +96,14 @@ useJsonLd(
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Sustainability</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
               Solar panels on our own roof, a biological wastewater system and a nature-friendly
-              garden – environmental awareness is part of our everyday life.
+              garden: environmental awareness is part of our everyday life.
             </p>
           </div>
           <div class="text-center">
             <Icon name="ph:house-line-duotone" class="mx-auto size-10 text-waldhonig-500" />
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Home atmosphere</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
-              No hotel formality – just a genuine home feeling. We are here for you and look forward
+              No hotel formality, just a genuine home feeling. We are here for you and look forward
               to personal encounters with our guests.
             </p>
           </div>
@@ -124,7 +124,7 @@ useJsonLd(
       <div class="mx-auto grid max-w-5xl gap-8 md:grid-cols-2 md:items-center">
         <NuxtImg
           src="/img/homepage/gebaeude-innenhof.webp"
-          alt="Pension Volgenandt – building and courtyard in Breitenbach"
+          alt="Building and courtyard of Pension Volgenandt in Breitenbach"
           class="w-full rounded-lg object-cover shadow-sm"
           loading="lazy"
           sizes="100vw md:50vw"
@@ -134,8 +134,8 @@ useJsonLd(
             Our guesthouse in Breitenbach
           </h2>
           <p class="leading-relaxed">
-            Our guesthouse is quietly situated on the edge of Breitenbach, nestled in the green
-            hills of the Eichsfeld. Seven rooms and holiday apartments accommodate couples, families
+            Our guesthouse sits quietly on the edge of Breitenbach, in the green hills of the
+            Eichsfeld. Seven rooms and holiday apartments accommodate couples, families
             and also business travellers.
           </p>
           <p class="leading-relaxed">

--- a/app/pages/en/activities/index.vue
+++ b/app/pages/en/activities/index.vue
@@ -60,7 +60,7 @@ const activityCards = [
   {
     title: 'Cycling',
     description:
-      'Whether a leisurely cycle along the Leine or a sporty route through the hills \u2013 there is something for everyone.',
+      'Whether a leisurely cycle along the Leine or a sporty route through the hills, there is something for everyone.',
     icon: 'ph:bicycle-duotone',
     to: '/en/activities/cycling/',
   },
@@ -72,7 +72,7 @@ const activityCards = [
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – entrance with garden view in summer"
+      image-alt="Entrance of Pension Volgenandt with a garden view in summer"
       title="Activities"
       subtitle="Explore the Eichsfeld"
     />
@@ -80,12 +80,12 @@ const activityCards = [
     <!-- 2. Personal intro -->
     <section class="mx-auto max-w-3xl px-6 py-12 md:py-16">
       <p class="text-lg leading-relaxed text-sage-800">
-        The Eichsfeld is a paradise for anyone who loves the outdoors. In the area around our
+        The Eichsfeld is ideal for anyone who loves the outdoors. In the area around our
         guesthouse you will find numerous hiking and cycling trails that lead through one of the
         most beautiful landscapes in Thuringia.
       </p>
       <p class="mt-4 text-lg leading-relaxed text-sage-800">
-        Whether sporty or leisurely, alone or with the family &ndash; we are happy to advise you on
+        Whether sporty or leisurely, alone or with the family, we are happy to advise you on
         the best routes and attractions nearby.
       </p>
     </section>
@@ -193,10 +193,10 @@ const activityCards = [
           </div>
           <div>
             <h2 class="font-serif text-2xl font-semibold text-sage-900">
-              Picnic Basket – Your Outing with a Twist
+              Picnic Basket: Your Outing with a Twist
             </h2>
             <p class="mt-3 leading-relaxed text-sage-700">
-              Take our homemade picnic basket along on your trip – to Burg Hanstein, Seeburger See,
+              Take our homemade picnic basket along on your trip, to Burg Hanstein, Seeburger See,
               or simply into the garden. Local, seasonal, with real crockery. From €19 per person.
             </p>
             <NuxtLink

--- a/app/pages/en/attractions/index.vue
+++ b/app/pages/en/attractions/index.vue
@@ -35,7 +35,7 @@ const { data: attractions } = await useAsyncData('en-attractions', () =>
 const activityCards = [
   {
     title: 'Hiking',
-    description: 'Hiking trails in the area \u2013 from leisurely to challenging.',
+    description: 'Hiking trails in the area, from leisurely to challenging.',
     icon: 'ph:mountains-duotone',
     to: '/en/activities/hiking/',
   },
@@ -53,7 +53,7 @@ const activityCards = [
     <!-- Banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – entrance with garden view in summer"
+      image-alt="Entrance of Pension Volgenandt with a garden view in summer"
       title="Attractions"
       subtitle="Explore the Eichsfeld"
     />

--- a/app/pages/en/contact.vue
+++ b/app/pages/en/contact.vue
@@ -53,7 +53,7 @@ const appConfig = useAppConfig()
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Entrance with garden view in summer"
+      image-alt="Entrance of Pension Volgenandt with a garden view in summer"
       :title="t('contact.heading', 'en')"
       :subtitle="t('contact.subtitle', 'en')"
     />
@@ -162,7 +162,7 @@ const appConfig = useAppConfig()
         <figure>
           <NuxtImg
             src="/img/content/gastgeber-portrait.webp"
-            alt="Simone and Ralf Volgenandt – Your hosts in Breitenbach"
+            alt="Simone and Ralf Volgenandt, your hosts in Breitenbach"
             class="aspect-[4/3] w-full rounded-lg object-cover"
             loading="lazy"
             sizes="100vw sm:50vw"
@@ -174,7 +174,7 @@ const appConfig = useAppConfig()
         <figure>
           <NuxtImg
             src="/img/homepage/gebaeude-innenhof.webp"
-            alt="Pension Volgenandt – Building and courtyard"
+            alt="Building and courtyard of Pension Volgenandt"
             class="aspect-[4/3] w-full rounded-lg object-cover"
             loading="lazy"
             sizes="100vw sm:50vw"

--- a/app/pages/en/families.vue
+++ b/app/pages/en/families.vue
@@ -79,7 +79,7 @@ const familyFeatures = [
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – entrance with garden view in summer"
+      image-alt="Entrance of Pension Volgenandt with a garden view in summer"
       title="For Families"
       subtitle="Where Little Ones Are the Stars"
     />
@@ -118,7 +118,7 @@ const familyFeatures = [
         />
         <div>
           <h2 class="font-serif text-2xl font-bold text-sage-900">
-            Our Garden – A Paradise for Children
+            Our Garden: Plenty of Space to Play
           </h2>
           <p class="mt-4 leading-relaxed text-sage-800">
             On our large green area, your children can play to their hearts' content and discover
@@ -127,7 +127,7 @@ const familyFeatures = [
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
             Bobby cars and tricycles are ready to go, and in the evening we watch the fireflies in
-            the garden together. For us, a family holiday is more than just a room – it is the
+            the garden together. For us, a family holiday is more than just a room: it is the
             little moments that count.
           </p>
         </div>
@@ -148,7 +148,7 @@ const familyFeatures = [
               greenery.
             </p>
             <p class="mt-4 leading-relaxed text-sage-800">
-              A barbecue set with utensils and pans can be booked as an extra – just bring your own
+              A barbecue set with utensils and pans can be booked as an extra, just bring your own
               charcoal.
             </p>
           </div>
@@ -183,7 +183,7 @@ const familyFeatures = [
             desired.
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
-            At breakfast, we are happy to cater to the little ones' wishes – just let us know.
+            At breakfast, we are happy to cater to the little ones' wishes, just let us know.
           </p>
         </div>
       </div>
@@ -199,7 +199,7 @@ const familyFeatures = [
           <li class="flex items-start gap-3">
             <Icon name="ph:check-circle-duotone" class="mt-0.5 size-6 shrink-0 text-sage-600" />
             <span class="leading-relaxed text-sage-800">
-              We provide cots and high chairs free of charge in every room – simply let us know when
+              We provide cots and high chairs free of charge in every room, simply let us know when
               booking.
             </span>
           </li>
@@ -212,13 +212,13 @@ const familyFeatures = [
           <li class="flex items-start gap-3">
             <Icon name="ph:check-circle-duotone" class="mt-0.5 size-6 shrink-0 text-sage-600" />
             <span class="leading-relaxed text-sage-800">
-              The Bear Park Worbis is only 6 km away – a wonderful experience for the whole family.
+              The Bear Park Worbis is only 6 km away: a wonderful experience for the whole family.
             </span>
           </li>
           <li class="flex items-start gap-3">
             <Icon name="ph:check-circle-duotone" class="mt-0.5 size-6 shrink-0 text-sage-600" />
             <span class="leading-relaxed text-sage-800">
-              Hiking trails and cycling routes nearby – easily accessible by car or rental bike,
+              Hiking trails and cycling routes nearby, easily accessible by car or rental bike,
               also suitable for little legs.
             </span>
           </li>

--- a/app/pages/en/news/index.vue
+++ b/app/pages/en/news/index.vue
@@ -33,7 +33,7 @@ const { data: articles } = await useAsyncData('en-news', () =>
   <div>
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – entrance with garden view in summer"
+      image-alt="Entrance of Pension Volgenandt with a garden view in summer"
       title="News"
       subtitle="Updates from the Region"
     />

--- a/app/pages/en/picnic/book.vue
+++ b/app/pages/en/picnic/book.vue
@@ -18,7 +18,7 @@ useHead({
 useSeoMeta({
   title: 'Request a Picnic Basket – Pension Volgenandt',
   description:
-    'Request your picnic basket now: choose your date, package and number of guests – we will get back to you within 24 hours.',
+    'Request your picnic basket now: choose your date, package and number of guests. We will get back to you within 24 hours.',
 })
 </script>
 

--- a/app/pages/en/picnic/index.vue
+++ b/app/pages/en/picnic/index.vue
@@ -21,9 +21,9 @@ useSeoMeta({
   title: 'Picnic Basket – Gourmet Breakfast to Go',
   ogTitle: 'Picnic Basket | Pension Volgenandt',
   description:
-    'Homemade, regional, packed with love. Book your picnic basket for the garden or the surrounding area – from 19 EUR per person.',
+    'Homemade, regional, packed with love. Book your picnic basket for the garden or the surrounding area, from 19 EUR per person.',
   ogDescription:
-    'Homemade, regional, packed with love. Book your picnic basket for the garden or the surrounding area – from 19 EUR per person.',
+    'Homemade, regional, packed with love. Book your picnic basket for the garden or the surrounding area, from 19 EUR per person.',
   ogImage: '/img/picknick/header-picknick.webp',
   ogType: 'website',
 })
@@ -109,7 +109,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
     <section class="mx-auto max-w-3xl px-6 py-12 text-center md:py-16">
       <p class="text-lg leading-relaxed text-sage-800">
         We pack a hand-filled wicker basket for you with homemade products, a real picnic blanket,
-        dishes and cutlery. You choose your favourite spot – in the garden right at the guesthouse
+        dishes and cutlery. You choose your favourite spot: in the garden right at the guesthouse
         or somewhere in the beautiful surrounding countryside.
       </p>
       <p class="mt-4 text-lg leading-relaxed text-sage-800">
@@ -153,7 +153,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
             >
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Choose a package</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
-              Brunch, coffee & cake, or sunset – pick the option that suits you best.
+              Brunch, coffee & cake, or sunset: pick the option that suits you best.
             </p>
           </li>
           <li class="flex flex-col items-center text-center">
@@ -183,7 +183,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
             >
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Pick up & enjoy</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
-              Collect the basket at the guesthouse, find your favourite spot – and enjoy the moment.
+              Collect the basket at the guesthouse, find your favourite spot and enjoy the moment.
             </p>
           </li>
         </ol>
@@ -196,7 +196,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
         <h2 class="mb-2 font-serif text-2xl font-semibold text-sage-900">
           Your spots in the garden
         </h2>
-        <p class="mb-8 text-sage-600">Right at the guesthouse – no car needed.</p>
+        <p class="mb-8 text-sage-600">Right at the guesthouse, no car needed.</p>
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
           <PicknickSpotCard
             v-for="spot in gardenSpots"
@@ -229,7 +229,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
     <section class="px-6 py-10 md:py-12">
       <div class="mx-auto max-w-3xl rounded-xl bg-sage-50 px-8 py-8 text-center">
         <p class="text-sage-700">
-          Simply take the basket with you – whether to Burg Hanstein, to Lake Seeburger See or on a
+          Simply take the basket with you, whether to Burg Hanstein, to Lake Seeburger See or on a
           hike through the Eichsfeld region. There are plenty of beautiful destinations in the area.
         </p>
         <NuxtLink
@@ -245,7 +245,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
     <section class="mx-auto max-w-5xl px-6 py-12 md:py-16">
       <h2 class="mb-2 font-serif text-2xl font-semibold text-sage-900">What is always included?</h2>
       <p class="mb-8 text-sage-600">
-        Every basket is fully equipped – real dishes, no disposables.
+        Every basket is fully equipped: real dishes, no disposables.
       </p>
       <PicknickBasketContents v-if="basket" :always="basket.always" :extras="basket.extras" />
     </section>
@@ -313,7 +313,7 @@ const { data: basket } = await useAsyncData('picknick-basket', () =>
       <div class="mx-auto max-w-2xl text-center">
         <h2 class="font-serif text-2xl font-semibold text-sage-900">Fancy a picnic?</h2>
         <p class="mt-3 text-sage-700">
-          Request your preferred date now – we will get back to you within 24 hours.
+          Request your preferred date now, we will get back to you within 24 hours.
         </p>
         <NuxtLink
           to="/en/picnic/book/"

--- a/app/pages/en/sustainability.vue
+++ b/app/pages/en/sustainability.vue
@@ -11,9 +11,9 @@ useSeoMeta({
   title: 'Sustainability',
   ogTitle: 'Sustainability | Pension Volgenandt',
   description:
-    'Solar energy, own well, wildflower meadow and vegetable garden – a sustainable holiday at Pension Volgenandt in the Eichsfeld.',
+    'Solar energy, own well, wildflower meadow and vegetable garden: a sustainable holiday at Pension Volgenandt in the Eichsfeld.',
   ogDescription:
-    'Solar energy, own well, wildflower meadow and vegetable garden – a sustainable holiday at Pension Volgenandt in the Eichsfeld.',
+    'Solar energy, own well, wildflower meadow and vegetable garden: a sustainable holiday at Pension Volgenandt in the Eichsfeld.',
   ogImage: '/img/content/garten-sonnenhut-blumen.webp',
   ogType: 'website',
 })
@@ -96,7 +96,7 @@ const sustainabilityFeatures = [
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – entrance with garden view in summer"
+      image-alt="Entrance of Pension Volgenandt with a garden view in summer"
       title="Sustainability"
       subtitle="Responsibility for Nature and Environment"
     />
@@ -104,7 +104,7 @@ const sustainabilityFeatures = [
     <!-- 2. Personal intro -->
     <section class="mx-auto max-w-3xl px-6 py-12 md:py-16">
       <p class="text-lg leading-relaxed text-sage-800">
-        Sustainability is not a trend for us – it is a matter of course. We live in the heart of
+        Sustainability is not a trend for us. It is a matter of course. We live in the heart of
         nature and want it to stay that way. That is why our sustainability rests on four pillars:
         our own energy generation, an independent water supply, active protection of biodiversity
         and a closed loop from the garden to the breakfast table.
@@ -133,12 +133,12 @@ const sustainabilityFeatures = [
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
             We also rely on efficient technology for hot water and take care to use resources
-            sparingly – without our guests having to compromise on comfort.
+            sparingly, without our guests having to compromise on comfort.
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
             For warmth and heating, we use a modern wood pellet system. Pellets made from regional
-            wood residues burn particularly cleanly and are considered climate-neutral – the CO₂
-            released was previously absorbed during tree growth.
+            wood residues burn particularly cleanly and are considered climate-neutral, since the
+            CO₂ released was previously absorbed during tree growth.
           </p>
         </div>
         <NuxtImg
@@ -157,18 +157,18 @@ const sustainabilityFeatures = [
         <div class="grid items-center gap-8 md:grid-cols-2">
           <NuxtImg
             src="/img/content/nachhaltigkeit-brunnen-quelle.webp"
-            alt="Water flowing from natural stone – the guesthouse's own well"
+            alt="Water flowing from natural stone at the guesthouse's own well"
             class="rounded-lg"
             loading="lazy"
             sizes="100vw md:50vw"
           />
           <div>
             <h2 class="font-serif text-2xl font-bold text-sage-900">
-              Our Own Water – From Well to Treatment Plant
+              Our Own Water: From Well to Treatment Plant
             </h2>
             <p class="mt-4 leading-relaxed text-sage-800">
               Our drinking water comes from our own well on the premises. A UV system treats the
-              water – reliably and entirely without chemical additives. This way, our guests enjoy
+              water reliably and entirely without chemical additives. This way, our guests enjoy
               fresh, clean water straight from nature.
             </p>
             <p class="mt-4 leading-relaxed text-sage-800">
@@ -195,11 +195,11 @@ const sustainabilityFeatures = [
               class="text-waldhonig-600 underline hover:text-waldhonig-700"
               >ImmerBunt</a
             >
-            – Germany's first wildflower meadow agency. The meadow provides bees, butterflies and
+            , Germany's first wildflower meadow agency. The meadow provides bees, butterflies and
             other insects with plenty of food.
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
-            In the deadwood corner, beetles, wild bees and hedgehogs find shelter – a deliberately
+            In the deadwood corner, beetles, wild bees and hedgehogs find shelter, a deliberately
             preserved piece of wild nature. Together with native wildflowers and heritage fruit
             varieties, a diverse habitat is created right on our doorstep.
           </p>
@@ -238,7 +238,7 @@ const sustainabilityFeatures = [
             <h2 class="font-serif text-2xl font-bold text-sage-900">From Garden to Table</h2>
             <p class="mt-4 leading-relaxed text-sage-800">
               Various fruit, berries and vegetables grow in our garden. We harvest everything
-              ourselves and process much of it – whether as homemade jam, fresh herbs or seasonal
+              ourselves and process much of it, whether as homemade jam, fresh herbs or seasonal
               fruit for breakfast.
             </p>
             <p class="mt-4 leading-relaxed text-sage-800">

--- a/app/pages/familie.vue
+++ b/app/pages/familie.vue
@@ -76,7 +76,7 @@ const familyFeatures = [
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Einfahrt mit Gartenblick im Sommer"
+      image-alt="Einfahrt der Pension Volgenandt mit Gartenblick im Sommer"
       title="Für Familien"
       subtitle="Bei uns sind die Kleinen die Größten"
     />
@@ -115,7 +115,7 @@ const familyFeatures = [
         />
         <div>
           <h2 class="font-serif text-2xl font-bold text-sage-900">
-            Unser Garten – ein Paradies für Kinder
+            Unser Garten: viel Platz zum Toben für Kinder
           </h2>
           <p class="mt-4 leading-relaxed text-sage-800">
             Auf unserer großen Grünfläche können Ihre Kinder nach Herzenslust spielen und die Natur
@@ -124,7 +124,7 @@ const familyFeatures = [
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
             Bobbycars und Dreirad stehen bereit, und am Abend beobachten wir gemeinsam die
-            Glühwürmchen im Garten. Für uns ist Familienurlaub mehr als nur ein Zimmer – es sind die
+            Glühwürmchen im Garten. Für uns ist Familienurlaub mehr als nur ein Zimmer: Es sind die
             kleinen Momente, die zählen.
           </p>
         </div>
@@ -145,7 +145,7 @@ const familyFeatures = [
               genießen.
             </p>
             <p class="mt-4 leading-relaxed text-sage-800">
-              Ein Grill-Set mit Besteck und Pfannen können Sie bei uns dazubuchen – Grillkohle
+              Ein Grill-Set mit Besteck und Pfannen können Sie bei uns dazubuchen, Grillkohle
               bringen Sie einfach selbst mit.
             </p>
           </div>
@@ -180,7 +180,7 @@ const familyFeatures = [
             lässt keine Wünsche offen.
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
-            Beim Frühstück gehen wir gerne auf die Wünsche der Kleinen ein – sprechen Sie uns
+            Beim Frühstück gehen wir gerne auf die Wünsche der Kleinen ein, sprechen Sie uns
             einfach an.
           </p>
         </div>
@@ -197,7 +197,7 @@ const familyFeatures = [
           <li class="flex items-start gap-3">
             <Icon name="ph:check-circle-duotone" class="mt-0.5 size-6 shrink-0 text-sage-600" />
             <span class="leading-relaxed text-sage-800">
-              Kinderbetten und Hochstühle stellen wir kostenlos in jedem Zimmer bereit – einfach bei
+              Kinderbetten und Hochstühle stellen wir kostenlos in jedem Zimmer bereit, einfach bei
               der Buchung angeben.
             </span>
           </li>
@@ -210,14 +210,14 @@ const familyFeatures = [
           <li class="flex items-start gap-3">
             <Icon name="ph:check-circle-duotone" class="mt-0.5 size-6 shrink-0 text-sage-600" />
             <span class="leading-relaxed text-sage-800">
-              Der Bärenpark Worbis ist nur 6 km entfernt – ein tolles Erlebnis für die ganze
+              Der Bärenpark Worbis ist nur 6 km entfernt: ein tolles Erlebnis für die ganze
               Familie.
             </span>
           </li>
           <li class="flex items-start gap-3">
             <Icon name="ph:check-circle-duotone" class="mt-0.5 size-6 shrink-0 text-sage-600" />
             <span class="leading-relaxed text-sage-800">
-              Wanderwege und Radtouren in der Umgebung – per Auto oder Leihrad gut erreichbar, auch
+              Wanderwege und Radtouren in der Umgebung, per Auto oder Leihrad gut erreichbar, auch
               für kleine Beine geeignet.
             </span>
           </li>

--- a/app/pages/feiern/index.vue
+++ b/app/pages/feiern/index.vue
@@ -9,9 +9,9 @@ useSeoMeta({
   title: 'Feiern im Garten | Hochzeit & Feste im Eichsfeld – Pension Volgenandt',
   ogTitle: 'Feiern im Garten | Pension Volgenandt',
   description:
-    'Hochzeit, Jugendweihe, Kommunion oder runder Geburtstag: Feiern Sie im Garten der Pension Volgenandt im Eichsfeld – Rundum-sorglos-Paket mit Catering, Eventplanung und Übernachtung. Jetzt Preis berechnen.',
+    'Hochzeit, Jugendweihe, Kommunion oder runder Geburtstag: Feiern Sie im Garten der Pension Volgenandt im Eichsfeld. Rundum-sorglos-Paket mit Catering, Eventplanung und Übernachtung. Jetzt Preis berechnen.',
   ogDescription:
-    'Ihr Fest im Grünen im Eichsfeld – Rundum-sorglos mit Catering, Eventplanung und Übernachtung für Ihre Gäste.',
+    'Ihr Fest im Grünen im Eichsfeld: Rundum-sorglos mit Catering, Eventplanung und Übernachtung für Ihre Gäste.',
   ogImage: '/img/garten/garten-rasen-baeume-sommer.webp',
   ogType: 'website',
   // Prices are still provisional (caterer/insurance not yet confirmed) and the
@@ -39,7 +39,7 @@ useJsonLd(
     url: 'https://www.pension-volgenandt.de/feiern/',
     image: ['https://www.pension-volgenandt.de/img/garten/garten-rasen-baeume-sommer.webp'],
     description:
-      'Full-Service-Eventlocation im Garten der Pension Volgenandt im Eichsfeld für Hochzeiten, Jugendweihe, Konfirmation, Kommunion, Taufe, runde Geburtstage und Jubiläen – inklusive Catering, Eventplanung und Übernachtungsmöglichkeit.',
+      'Full-Service-Eventlocation im Garten der Pension Volgenandt im Eichsfeld für Hochzeiten, Jugendweihe, Konfirmation, Kommunion, Taufe, runde Geburtstage und Jubiläen, inklusive Catering, Eventplanung und Übernachtungsmöglichkeit.',
     areaServed: {
       '@type': 'Place',
       name: 'Eichsfeld, Thüringen',
@@ -54,7 +54,7 @@ useJsonLd(
 const steps = [
   {
     title: 'Anfrage',
-    text: 'Senden Sie uns über den Rechner unverbindlich Ihre Eckdaten – Anlass, Termin und Gästezahl.',
+    text: 'Senden Sie uns über den Rechner unverbindlich Ihre Eckdaten: Anlass, Termin und Gästezahl.',
   },
   {
     title: 'Beratung',
@@ -66,7 +66,7 @@ const steps = [
   },
   {
     title: 'Feiern',
-    text: 'Genießen Sie Ihren Tag im Grünen – wir koordinieren vor Ort, Ihre Gäste übernachten bei uns.',
+    text: 'Verbringen Sie Ihren Tag im Grünen: Wir koordinieren vor Ort, Ihre Gäste übernachten bei uns.',
   },
 ]
 
@@ -74,22 +74,22 @@ const included = [
   {
     icon: 'ph:key-duotone',
     title: 'Das ganze Grundstück für Sie allein',
-    text: 'Für Ihr Festwochenende buchen Sie die komplette Pension exklusiv – alle Zimmer und Ferienwohnungen für bis zu 18 Übernachtungsgäste. Keine anderen Gäste – nur Sie, Ihre Familie und Ihre Freunde, ganz unter sich.',
+    text: 'Für Ihr Festwochenende buchen Sie die komplette Pension exklusiv: alle Zimmer und Ferienwohnungen für bis zu 18 Übernachtungsgäste. Keine anderen Gäste, nur Sie, Ihre Familie und Ihre Freunde, ganz unter sich.',
   },
   {
     icon: 'ph:tree-duotone',
     title: 'Unser Garten als festliche Kulisse',
-    text: 'Ein gepflegter, ruhiger Garten im Eichsfeld – intim, idyllisch und mitten im Grünen. Hier feiern Sie stimmungsvoll und ungestört, auf Wunsch mit Festzelt.',
+    text: 'Ein gepflegter, ruhiger Garten im Eichsfeld, intim und mitten im Grünen. Hier feiern Sie stimmungsvoll und ungestört, auf Wunsch mit Festzelt.',
   },
   {
     icon: 'ph:fork-knife-duotone',
     title: 'Catering vom Partner-Caterer',
-    text: 'Vom rustikalen Buffet bis zum servierten Menü – regional und auf Ihren Anlass abgestimmt, geliefert von unserem erfahrenen Partner-Caterer.',
+    text: 'Vom rustikalen Buffet bis zum servierten Menü: regional und auf Ihren Anlass abgestimmt, geliefert von unserem erfahrenen Partner-Caterer.',
   },
   {
     icon: 'ph:calendar-check-duotone',
     title: 'Eventplanung aus einer Hand',
-    text: 'Wir planen, organisieren und koordinieren im Vorfeld – damit Sie sich an Ihrem Tag ganz auf Ihre Gäste konzentrieren können.',
+    text: 'Wir planen, organisieren und koordinieren im Vorfeld, damit Sie sich an Ihrem Tag ganz auf Ihre Gäste konzentrieren können.',
   },
 ]
 </script>
@@ -118,7 +118,7 @@ const included = [
           Feiern Sie Ihr Fest in unserem Garten
         </h1>
         <p class="mt-3 max-w-2xl text-lg text-white/90 md:text-xl">
-          Hochzeit, Jugendweihe, Kommunion oder runder Geburtstag – rundum sorglos im Grünen.
+          Hochzeit, Jugendweihe, Kommunion oder runder Geburtstag: rundum sorglos im Grünen.
         </p>
         <a
           href="#rechner"
@@ -132,17 +132,17 @@ const included = [
     <!-- 2. Intro -->
     <section class="mx-auto max-w-3xl px-6 py-12 text-center md:py-16">
       <h2 class="font-serif text-2xl font-semibold text-sage-900 md:text-3xl">
-        Ihr Sommerfest im Eichsfeld – ganz ohne Stress
+        Ihr Sommerfest im Eichsfeld, ganz ohne Stress
       </h2>
       <p class="mt-4 text-lg leading-relaxed text-sage-800">
         Für Ihr Festwochenende gehört Ihnen das <strong>gesamte Grundstück ganz allein</strong>: Sie
         buchen die komplette Pension mit allen Zimmern für das Wochenende, Ihre Gäste übernachten
-        direkt vor Ort – und wir organisieren Ihr Fest von A bis Z. Dazu ein
+        direkt vor Ort, und wir organisieren Ihr Fest von A bis Z. Dazu ein
         <strong>Rundum-sorglos-Paket</strong> mit Catering über unseren Partner-Caterer und
         persönlicher Eventplanung.
       </p>
       <p class="mt-4 text-lg leading-relaxed text-sage-800">
-        Keine Nachbarn, keine Sperrstunde, kein Stress – Sie feiern, wir kümmern uns um den Rest.
+        Keine Nachbarn, keine Sperrstunde, kein Stress: Sie feiern, wir kümmern uns um den Rest.
       </p>
     </section>
 
@@ -153,7 +153,7 @@ const included = [
           Für jeden besonderen Anlass
         </h2>
         <p class="mb-10 text-center text-sage-600">
-          Ob feierlich oder ausgelassen – wir gestalten Ihren Tag.
+          Ob feierlich oder ausgelassen: wir gestalten Ihren Tag.
         </p>
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
           <div
@@ -178,7 +178,7 @@ const included = [
           Unser Komplettpaket
         </h2>
         <p class="mb-10 text-center text-sage-600">
-          Alles aus einer Hand – damit Sie entspannt feiern können.
+          Alles aus einer Hand, damit Sie entspannt feiern können.
         </p>
         <div class="grid gap-6 sm:grid-cols-2">
           <div
@@ -252,7 +252,7 @@ const included = [
             <h2 class="mt-1 font-serif text-2xl font-semibold text-sage-900">Tina Volgenandt</h2>
             <p class="mt-3 leading-relaxed text-sage-700">
               Ihre Feier ist bei mir in erfahrenen Händen: Als Eventmanagerin plane, organisiere und
-              koordiniere ich Ihr Fest persönlich – von der ersten Idee bis zum letzten Detail am
+              koordiniere ich Ihr Fest persönlich, von der ersten Idee bis zum letzten Detail am
               Veranstaltungstag. So können Sie sich ganz auf Ihre Gäste und Ihren Tag konzentrieren.
             </p>
             <a
@@ -277,7 +277,7 @@ const included = [
         </h2>
         <p class="mt-3 mb-8 text-center text-sage-600">
           Unser Konfigurator führt Sie Schritt für Schritt durch alle Möglichkeiten. Bei jeder
-          Auswahl sehen Sie sofort, was sie für Ihre Feier bedeutet und was sie kostet – am Ende
+          Auswahl sehen Sie sofort, was sie für Ihre Feier bedeutet und was sie kostet. Am Ende
           steht Ihr unverbindlicher Gesamt-Richtwert. Danach melden wir uns mit einem persönlichen
           Angebot.
         </p>
@@ -296,7 +296,7 @@ const included = [
             <Icon name="ph:shield-check-duotone" class="mx-auto size-9 text-waldhonig-500" />
             <h3 class="mt-3 font-serif text-base font-semibold text-sage-900">Völlig privat</h3>
             <p class="mt-2 text-sm text-sage-600">
-              Das ganze Grundstück gehört für das Wochenende nur Ihnen – keine Nachbarn, keine
+              Das ganze Grundstück gehört für das Wochenende nur Ihnen: keine Nachbarn, keine
               fremden Gäste.
             </p>
           </div>
@@ -320,7 +320,7 @@ const included = [
             <Icon name="ph:users-three-duotone" class="mx-auto size-9 text-waldhonig-500" />
             <h3 class="mt-3 font-serif text-base font-semibold text-sage-900">10 bis 80 Gäste</h3>
             <p class="mt-2 text-sm text-sage-600">
-              Von der kleinen Familienfeier bis zum großen Fest – in der Saison von Mai bis
+              Von der kleinen Familienfeier bis zum großen Fest, in der Saison von Mai bis
               September.
             </p>
           </div>
@@ -338,7 +338,7 @@ const included = [
       <div class="mx-auto max-w-2xl text-center">
         <h2 class="font-serif text-2xl font-semibold text-sage-900">Lieber persönlich sprechen?</h2>
         <p class="mt-3 text-sage-700">
-          Vereinbaren Sie einen Gesprächstermin – geben Sie einfach Ihren Wunschtermin an, und wir
+          Vereinbaren Sie einen Gesprächstermin: Geben Sie einfach Ihren Wunschtermin an, und wir
           melden uns bei Ihnen.
         </p>
         <div class="mt-8">

--- a/app/pages/kontakt.vue
+++ b/app/pages/kontakt.vue
@@ -73,7 +73,7 @@ useJsonLd(
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Einfahrt mit Gartenblick im Sommer"
+      image-alt="Einfahrt der Pension Volgenandt mit Gartenblick im Sommer"
       :title="t('contact.heading', locale)"
       :subtitle="t('contact.subtitle', locale)"
     />
@@ -182,7 +182,7 @@ useJsonLd(
         <figure>
           <NuxtImg
             src="/img/content/gastgeber-portrait.webp"
-            alt="Simone und Ralf Volgenandt – Ihre Gastgeber in Breitenbach"
+            alt="Simone und Ralf Volgenandt, Ihre Gastgeber in Breitenbach"
             class="aspect-[4/3] w-full rounded-lg object-cover"
             loading="lazy"
             sizes="100vw sm:50vw"
@@ -194,7 +194,7 @@ useJsonLd(
         <figure>
           <NuxtImg
             src="/img/homepage/gebaeude-innenhof.webp"
-            alt="Pension Volgenandt – Gebäude und Innenhof"
+            alt="Gebäude und Innenhof der Pension Volgenandt"
             class="aspect-[4/3] w-full rounded-lg object-cover"
             loading="lazy"
             sizes="100vw sm:50vw"

--- a/app/pages/monteurzimmer.vue
+++ b/app/pages/monteurzimmer.vue
@@ -9,9 +9,9 @@ useSeoMeta({
   title: 'Monteurzimmer Leinefelde | Pension Volgenandt Eichsfeld',
   ogTitle: 'Monteurzimmer Leinefelde | Pension Volgenandt Eichsfeld',
   description:
-    'Günstige Monteurzimmer in Leinefelde-Worbis. WLAN, Parkplatz, Küchenzugang – ideal für Handwerker & Firmen. Ab 50 €/Nacht.',
+    'Günstige Monteurzimmer in Leinefelde-Worbis mit WLAN, Parkplatz und Küchenzugang. Ideal für Handwerker & Firmen, ab 50 €/Nacht.',
   ogDescription:
-    'Günstige Monteurzimmer in Leinefelde-Worbis. WLAN, Parkplatz, Küchenzugang – ideal für Handwerker & Firmen. Ab 50 €/Nacht.',
+    'Günstige Monteurzimmer in Leinefelde-Worbis mit WLAN, Parkplatz und Küchenzugang. Ideal für Handwerker & Firmen, ab 50 €/Nacht.',
   ogImage: `${siteUrl}/img/hero/hero-poster.webp`,
   ogType: 'website',
 })

--- a/app/pages/nachhaltigkeit.vue
+++ b/app/pages/nachhaltigkeit.vue
@@ -9,9 +9,9 @@ useSeoMeta({
   title: 'Nachhaltigkeit',
   ogTitle: 'Nachhaltigkeit | Pension Volgenandt',
   description:
-    'Solarenergie, eigener Brunnen, Blühwiese und Gemüsegarten – nachhaltig urlauben in der Pension Volgenandt im Eichsfeld.',
+    'Solarenergie, eigener Brunnen, Blühwiese und Gemüsegarten: nachhaltig urlauben in der Pension Volgenandt im Eichsfeld.',
   ogDescription:
-    'Solarenergie, eigener Brunnen, Blühwiese und Gemüsegarten – nachhaltig urlauben in der Pension Volgenandt im Eichsfeld.',
+    'Solarenergie, eigener Brunnen, Blühwiese und Gemüsegarten: nachhaltig urlauben in der Pension Volgenandt im Eichsfeld.',
   ogImage: '/img/content/garten-sonnenhut-blumen.webp',
   ogType: 'website',
 })
@@ -93,7 +93,7 @@ const sustainabilityFeatures = [
     <!-- 1. Thin photo banner -->
     <SharedPageBanner
       image="/img/garten/einfahrt-sommer.webp"
-      image-alt="Pension Volgenandt – Einfahrt mit Gartenblick im Sommer"
+      image-alt="Einfahrt der Pension Volgenandt mit Gartenblick im Sommer"
       title="Nachhaltigkeit"
       subtitle="Verantwortung für Natur und Umgebung"
     />
@@ -131,12 +131,12 @@ const sustainabilityFeatures = [
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
             Auch beim Warmwasser setzen wir auf effiziente Technik und achten darauf, Ressourcen
-            sparsam einzusetzen – ohne dass unsere Gäste auf Komfort verzichten müssen.
+            sparsam einzusetzen, ohne dass unsere Gäste auf Komfort verzichten müssen.
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
             Für Wärme und Heizung nutzen wir eine moderne Holzpelletsanlage. Pellets aus regionalen
-            Holzresten verbrennen besonders sauber und gelten als klimaneutral – das freigesetzte
-            CO₂ wurde zuvor beim Baumwachstum gebunden.
+            Holzresten verbrennen besonders sauber und gelten als klimaneutral, da das freigesetzte
+            CO₂ zuvor beim Baumwachstum gebunden wurde.
           </p>
         </div>
         <NuxtImg
@@ -155,18 +155,18 @@ const sustainabilityFeatures = [
         <div class="grid items-center gap-8 md:grid-cols-2">
           <NuxtImg
             src="/img/content/nachhaltigkeit-brunnen-quelle.webp"
-            alt="Wasser sprudelt aus einem Naturstein – eigener Brunnen der Pension Volgenandt"
+            alt="Wasser sprudelt aus einem Naturstein am eigenen Brunnen der Pension Volgenandt"
             class="rounded-lg"
             loading="lazy"
             sizes="100vw md:50vw"
           />
           <div>
             <h2 class="font-serif text-2xl font-bold text-sage-900">
-              Eigenes Wasser – vom Brunnen bis zur Kläranlage
+              Eigenes Wasser: vom Brunnen bis zur Kläranlage
             </h2>
             <p class="mt-4 leading-relaxed text-sage-800">
               Unser Trinkwasser kommt aus einem eigenen Brunnen auf dem Gelände. Eine UV-Anlage
-              bereitet das Wasser auf – zuverlässig und ganz ohne chemische Zusätze. So genießen
+              bereitet das Wasser auf, zuverlässig und ganz ohne chemische Zusätze. So genießen
               unsere Gäste frisches, sauberes Wasser direkt aus der Natur.
             </p>
             <p class="mt-4 leading-relaxed text-sage-800">
@@ -194,11 +194,11 @@ const sustainabilityFeatures = [
               class="text-waldhonig-600 underline hover:text-waldhonig-700"
               >ImmerBunt</a
             >
-            angelegt – Deutschlands erster Blühwiesen-Agentur. Die Wiese bietet Bienen,
+            angelegt, Deutschlands erster Blühwiesen-Agentur. Die Wiese bietet Bienen,
             Schmetterlingen und anderen Insekten reichlich Nahrung.
           </p>
           <p class="mt-4 leading-relaxed text-sage-800">
-            In der Totholzecke finden Käfer, Wildbienen und Igel Unterschlupf – ein bewusst
+            In der Totholzecke finden Käfer, Wildbienen und Igel Unterschlupf: ein bewusst
             belassenes Stück wilde Natur. Zusammen mit einheimischen Wildblumen und alten Obstarten
             entsteht ein vielfältiger Lebensraum direkt vor unserer Haustür.
           </p>
@@ -237,7 +237,7 @@ const sustainabilityFeatures = [
             <h2 class="font-serif text-2xl font-bold text-sage-900">Vom Garten auf den Tisch</h2>
             <p class="mt-4 leading-relaxed text-sage-800">
               In unserem Garten wachsen verschiedene Obstarten, Beeren und Gemüse. Wir ernten alles
-              selbst und verarbeiten vieles davon – ob als hausgemachte Marmelade, frische Kräuter
+              selbst und verarbeiten vieles davon, ob als hausgemachte Marmelade, frische Kräuter
               oder saisonales Obst zum Frühstück.
             </p>
             <p class="mt-4 leading-relaxed text-sage-800">

--- a/app/pages/picknick/index.vue
+++ b/app/pages/picknick/index.vue
@@ -9,9 +9,9 @@ useSeoMeta({
   title: 'Picknick-Korb ab 19 € | Pension Volgenandt Eichsfeld',
   ogTitle: 'Picknick-Korb | Pension Volgenandt',
   description:
-    'Hausgemacht, regional, mit Herz gepackt. Buchen Sie Ihren Picknick-Korb für den Garten oder die Umgebung – ab 19 € pro Person.',
+    'Hausgemacht, regional, mit Herz gepackt. Buchen Sie Ihren Picknick-Korb für den Garten oder die Umgebung, ab 19 € pro Person.',
   ogDescription:
-    'Hausgemacht, regional, mit Herz gepackt. Buchen Sie Ihren Picknick-Korb für den Garten oder die Umgebung – ab 19 € pro Person.',
+    'Hausgemacht, regional, mit Herz gepackt. Buchen Sie Ihren Picknick-Korb für den Garten oder die Umgebung, ab 19 € pro Person.',
   ogImage: '/img/picknick/header-picknick.webp',
   ogType: 'website',
 })
@@ -157,7 +157,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
     <section class="mx-auto max-w-3xl px-6 py-12 text-center md:py-16">
       <p class="text-lg leading-relaxed text-sage-800">
         Wir packen für Sie einen Picknickkorb mit hausgemachten Produkten, echter Picknickdecke,
-        Geschirr und Besteck. Sie suchen sich Ihren Lieblingsplatz aus – im Garten direkt an der
+        Geschirr und Besteck. Sie suchen sich Ihren Lieblingsplatz aus: im Garten direkt an der
         Pension oder irgendwo in der wunderschönen Umgebung.
       </p>
       <p class="mt-4 text-lg leading-relaxed text-sage-800">
@@ -201,7 +201,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
             >
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Paket wählen</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
-              Brunch oder Sonnenuntergang – suchen Sie sich Ihr Wunschangebot aus.
+              Brunch oder Sonnenuntergang: suchen Sie sich Ihr Wunschangebot aus.
             </p>
           </li>
           <li class="flex flex-col items-center text-center">
@@ -231,7 +231,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
             >
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Abholen & genießen</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
-              Korb an der Pension abholen, Lieblingsplatz aussuchen – und den Moment genießen.
+              Korb an der Pension abholen, Lieblingsplatz aussuchen und den Moment genießen.
             </p>
           </li>
         </ol>
@@ -242,7 +242,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
     <section class="px-6 py-12 md:py-16">
       <div class="mx-auto max-w-6xl">
         <h2 class="mb-2 font-serif text-2xl font-semibold text-sage-900">Ihre Plätze im Garten</h2>
-        <p class="mb-8 text-sage-600">Direkt an der Pension – kein Auto nötig.</p>
+        <p class="mb-8 text-sage-600">Direkt an der Pension, kein Auto nötig.</p>
         <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
           <PicknickSpotCard
             v-for="spot in gardenSpots"
@@ -310,7 +310,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
     <section class="px-6 py-10 md:py-12">
       <div class="mx-auto max-w-3xl rounded-xl bg-sage-50 px-8 py-8 text-center">
         <p class="text-sage-700">
-          Den Korb einfach mitnehmen – ob zur Burg Hanstein, an den Seeburger See oder auf eine
+          Den Korb einfach mitnehmen, ob zur Burg Hanstein, an den Seeburger See oder auf eine
           Wanderung im Eichsfeld. Schöne Ausflugsziele gibt es hier in der Umgebung genug.
         </p>
         <NuxtLink
@@ -326,7 +326,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
     <section class="mx-auto max-w-5xl px-6 py-12 md:py-16">
       <h2 class="mb-2 font-serif text-2xl font-semibold text-sage-900">Was ist immer dabei?</h2>
       <p class="mb-8 text-sage-600">
-        Jeder Korb ist vollständig ausgestattet – echtes Geschirr, keine Einwegprodukte.
+        Jeder Korb ist vollständig ausgestattet: echtes Geschirr, keine Einwegprodukte.
       </p>
       <PicknickBasketContents v-if="basket" :always="basket.always" :extras="basket.extras" />
     </section>
@@ -394,7 +394,7 @@ onBeforeUnmount(() => gardenObserver?.disconnect())
       <div class="mx-auto max-w-2xl text-center">
         <h2 class="font-serif text-2xl font-semibold text-sage-900">Lust auf ein Picknick?</h2>
         <p class="mt-3 text-sage-700">
-          Jetzt Ihren Wunschtermin anfragen – wir melden uns innerhalb von 24 Stunden.
+          Jetzt Ihren Wunschtermin anfragen, wir melden uns innerhalb von 24 Stunden.
         </p>
         <NuxtLink
           to="/picknick/buchen/"

--- a/app/pages/willkommen.vue
+++ b/app/pages/willkommen.vue
@@ -72,7 +72,7 @@ const { locale } = useLocale()
     <!-- Hero photo banner -->
     <SharedPageBanner
       image="/img/content/gastgeber-portrait.webp"
-      image-alt="Simone und Ralf Volgenandt – Ihre Gastgeber in Breitenbach"
+      image-alt="Simone und Ralf Volgenandt, Ihre Gastgeber in Breitenbach"
       title="Über uns"
       subtitle="Herzlich willkommen in unserem Zuhause"
     />
@@ -100,7 +100,7 @@ const { locale } = useLocale()
             <Icon name="ph:sun-duotone" class="mx-auto size-10 text-waldhonig-500" />
             <h3 class="mt-4 font-serif text-lg font-semibold text-sage-900">Nachhaltigkeit</h3>
             <p class="mt-2 text-sm leading-relaxed text-sage-600">
-              Solarenergie vom eigenen Dach, biologische Kläranlage und ein naturnaher Garten –
+              Solarenergie vom eigenen Dach, biologische Kläranlage und ein naturnaher Garten:
               Umweltbewusstsein ist Teil unseres Alltags.
             </p>
           </div>
@@ -131,7 +131,7 @@ const { locale } = useLocale()
       <div class="mx-auto grid max-w-5xl gap-8 md:grid-cols-2 md:items-center">
         <NuxtImg
           src="/img/homepage/gebaeude-innenhof.webp"
-          alt="Pension Volgenandt – Gebäude und Innenhof in Breitenbach"
+          alt="Gebäude und Innenhof der Pension Volgenandt in Breitenbach"
           class="w-full rounded-lg object-cover shadow-sm"
           loading="lazy"
           sizes="100vw md:50vw"

--- a/content/attractions-en/baerenpark-worbis.yml
+++ b/content/attractions-en/baerenpark-worbis.yml
@@ -1,7 +1,7 @@
 name: 'Alternative Bear Park Worbis'
 slug: baerenpark-worbis
 seoTitle: 'Bear Park Worbis | Guesthouse near Bear Park'
-seoDescription: 'Visit the Alternative Bear Park Worbis – just 6 km from our guesthouse. Tips and accommodation in the Eichsfeld region.'
+seoDescription: 'Visit the Alternative Bear Park Worbis, just 6 km from our guesthouse. Tips and accommodation in the Eichsfeld region.'
 heroImage: /img/attractions/baerenpark-worbis.webp
 heroImageAlt: 'Brown bear in the naturalistic enclosure of the Alternative Bear Park Worbis'
 distanceKm: 6
@@ -31,11 +31,10 @@ content: >-
 
   The bear park is actively committed to animal welfare and raises
   awareness about the issues of private wild animal keeping. A visit
-  is not only a wonderful experience but also supports an important
-  cause.
+  is a wonderful experience, and it supports an important cause too.
 hostTip: >-
   Come early in the morning when the bears are most active. The
-  trail takes about 1-2 hours. Bring sturdy footwear – the path
+  trail takes about 1-2 hours. Bring sturdy footwear. The path
   leads through hilly woodland.
 bestTimeToVisit: 'Spring to autumn'
 website: 'https://www.baer.de'
@@ -46,7 +45,7 @@ gallery:
   - src: /img/attractions/baerenpark-baer-baumstamm.webp
     alt: 'Brown bear relaxing on a tree trunk in the naturalistic enclosure'
   - src: /img/attractions/baerenpark-baer-nahaufnahme.webp
-    alt: 'Brown bear – expressive close-up of the head'
+    alt: "Close-up of a brown bear's head"
   - src: /img/attractions/baerenpark-baer-wald-fruehling.webp
     alt: 'Brown bear roaming its spacious woodland enclosure in spring'
   - src: /img/attractions/baerenpark-baer-wald.webp

--- a/content/attractions-en/baumkronenpfad-hainich.yml
+++ b/content/attractions-en/baumkronenpfad-hainich.yml
@@ -1,9 +1,9 @@
 name: 'Treetop Walk Hainich'
 slug: baumkronenpfad-hainich
 seoTitle: 'Treetop Walk Hainich | Guesthouse near National Park'
-seoDescription: 'Walk among the treetops of the UNESCO World Heritage Site Hainich – just 54 km from our guesthouse. Treetop walkway at 44 metres height.'
+seoDescription: 'Walk among the treetops of the UNESCO World Heritage Site Hainich, just 54 km from our guesthouse. Treetop walkway at 44 metres height.'
 heroImage: /img/attractions/baumkronenpfad-hainich-aussicht.webp
-heroImageAlt: 'Treetop Walk Hainich – observation tower with sweeping views over the national park'
+heroImageAlt: 'Treetop Walk Hainich, observation tower with sweeping views over the national park'
 distanceKm: 54
 drivingMinutes: 58
 category: natur
@@ -15,14 +15,14 @@ intro: >-
   right through the canopy.
 content: >-
   About 54 kilometres southwest of our guesthouse lies Hainich
-  National Park – a unique natural paradise that has been a UNESCO
-  World Natural Heritage Site since 2011. Here, Germany's largest
+  National Park, a UNESCO World Natural Heritage Site since 2011.
+  Here, Germany's largest
   contiguous deciduous forest grows largely undisturbed.
 
 
   The highlight for visitors is the treetop walkway with its 44-metre
   observation tower. The 540-metre-long path leads barrier-free
-  through the different layers of the forest – from the forest floor
+  through the different layers of the forest, from the forest floor
   up into the canopy. From above, a fascinating view opens up over
   the endless leafy roof.
 
@@ -33,7 +33,7 @@ content: >-
   varying lengths lead through the national park.
 
 
-  The Hainich is an unforgettable nature experience, especially in
+  The Hainich makes for a wonderful outing, especially in
   spring when the forest floor is covered with wild garlic and wood
   anemones, and in autumn with its vibrant foliage colours.
 hostTip: >-

--- a/content/attractions-en/brotmuseum-ebergotzen.yml
+++ b/content/attractions-en/brotmuseum-ebergotzen.yml
@@ -1,7 +1,7 @@
 name: 'European Bread Museum Ebergotzen'
 slug: brotmuseum-ebergotzen
-seoTitle: 'European Bread Museum Ebergotzen – Cultural Excursion in the Eichsfeld'
-seoDescription: 'The European Bread Museum in Ebergotzen showcases 10,000 years of bread culture on a historic farmstead with windmill and herb garden – 35 km from Pension Volgenandt.'
+seoTitle: 'European Bread Museum Ebergotzen: A Cultural Excursion in the Eichsfeld'
+seoDescription: 'The European Bread Museum in Ebergotzen showcases 10,000 years of bread culture on a historic farmstead with windmill and herb garden, 35 km from Pension Volgenandt.'
 heroImage: /img/attractions/brotmuseum-windmuehle-kutsche.webp
 heroImageAlt: 'Historic windmill and old carriage on the outdoor grounds of the European Bread Museum Ebergotzen'
 distanceKm: 35
@@ -10,7 +10,7 @@ category: kultur
 shortDescription: '10,000 years of bread history on a historic farmstead with windmill'
 intro: >-
   The European Bread Museum in Ebergotzen tells the story of bread
-  on a sprawling historic farmstead – from the Stone Age to the
+  on a sprawling historic farmstead, from the Stone Age to the
   present day. With a windmill, herb garden and engaging exhibitions,
   it makes a great outing for the whole family.
 content: >-
@@ -34,10 +34,10 @@ content: >-
   are often held on weekends.
 
 
-  The museum is located right on the Leinepfad trail – a visit can
-  easily be combined with a cycling tour or a walk along the river.
+  The museum is located right on the Leinepfad trail, so a visit
+  can easily be combined with a cycling tour or a walk along the river.
 hostTip: >-
-  Allow at least two hours – the outdoor grounds are more extensive
+  Allow at least two hours. The outdoor grounds are more extensive
   than you might expect. If possible, visit on a weekend when baking
   demonstrations are often held and freshly baked bread can be tasted.
 bestTimeToVisit: 'April to October'

--- a/content/attractions-en/burg-bodenstein.yml
+++ b/content/attractions-en/burg-bodenstein.yml
@@ -1,7 +1,7 @@
 name: 'Bodenstein Castle'
 slug: burg-bodenstein
 seoTitle: 'Bodenstein Castle | Guesthouse near Bodenstein Castle'
-seoDescription: 'Discover the medieval Bodenstein Castle in the Eichsfeld – just 9 km from our guesthouse. Panoramic views, chapel and castle cafe.'
+seoDescription: 'Discover the medieval Bodenstein Castle in the Eichsfeld, just 9 km from our guesthouse. Panoramic views, chapel and castle cafe.'
 heroImage: ''
 heroImageAlt: ''
 distanceKm: 9
@@ -28,7 +28,7 @@ content: >-
 
   The castle cafe invites you to linger with homemade cakes and regional
   specialities. The terrace with its view into the valley is especially
-  recommended – a wonderful spot for a coffee break after your tour.
+  recommended, a wonderful spot for a coffee break after your tour.
 
 
   Several hiking trails lead through the wooded hillsides around the

--- a/content/attractions-en/burg-hanstein.yml
+++ b/content/attractions-en/burg-hanstein.yml
@@ -1,9 +1,9 @@
 name: 'Hanstein Castle Ruins'
 slug: burg-hanstein
 seoTitle: 'Hanstein Castle Ruins | Guesthouse near Hanstein Castle'
-seoDescription: 'Visit the Hanstein Castle ruins near Bornhagen – one of the largest castle ruins in Central Germany. Just 40 km from our guesthouse.'
+seoDescription: 'Visit the Hanstein Castle ruins near Bornhagen, one of the largest castle ruins in Central Germany. Just 40 km from our guesthouse.'
 heroImage: /img/attractions/burg-hanstein-fassade.webp
-heroImageAlt: 'Hanstein Castle ruins – imposing facade seen from below'
+heroImageAlt: 'Hanstein Castle ruins, imposing facade seen from below'
 distanceKm: 40
 drivingMinutes: 35
 category: kultur
@@ -11,7 +11,7 @@ shortDescription: 'One of the largest castle ruins in Central Germany with panor
 intro: >-
   The Hanstein Castle ruins near Bornhagen rank among the largest and
   most impressive castle ruins in Central Germany. From the mighty
-  walls you can enjoy an unforgettable panoramic view over the Werra
+  walls you can enjoy a sweeping panoramic view over the Werra
   Valley and the Eichsfeld.
 content: >-
   Just 40 kilometres from our guesthouse, the Hanstein Castle ruins
@@ -39,7 +39,7 @@ content: >-
 hostTip: >-
   Visit the castle on a clear day for the best panoramic views. In
   summer, regular events and medieval festivals are held at the
-  castle – ask us about upcoming dates.
+  castle. Ask us about upcoming dates.
 bestTimeToVisit: 'Spring to autumn in clear weather'
 website: 'https://www.burgruine-hanstein.de'
 coordinates:

--- a/content/attractions-en/burg-scharfenstein.yml
+++ b/content/attractions-en/burg-scharfenstein.yml
@@ -1,7 +1,7 @@
 name: 'Scharfenstein Castle – the Whisky Castle'
 slug: burg-scharfenstein
 seoTitle: 'Scharfenstein Castle & Whisky World | Guesthouse near the Whisky Castle'
-seoDescription: 'Experience the Whisky Castle Scharfenstein with its Whisky World and the Nine Springs Single Malt – just 10 km from our guesthouse in the Eichsfeld.'
+seoDescription: 'Visit the Whisky Castle Scharfenstein with its Whisky World and the Nine Springs Single Malt, just 10 km from our guesthouse in the Eichsfeld.'
 heroImage: /img/attractions/burg-scharfenstein.webp
 heroImageAlt: 'Scharfenstein Castle with characteristic half-timbering and heraldic shutters'
 distanceKm: 10
@@ -11,13 +11,13 @@ shortDescription: 'Medieval castle with Whisky World, boutique hotel and panoram
 intro: >-
   Scharfenstein Castle near Beuren combines over 800 years of history
   with a unique whisky experience. In the Whisky World, the
-  award-winning Nine Springs Single Malt Whisky matures – made with
+  award-winning Nine Springs Single Malt Whisky matures, made with
   the soft spring water of the Eichsfeld.
 content: >-
   Just about 10 kilometres from our guesthouse, Scharfenstein Castle
   sits on a rocky spur above the Leine Valley. The castle was built
   around 1200 by the Counts of Gleichen and has had an eventful
-  history – from its destruction during the Peasants' War in 1525,
+  history, from its destruction during the Peasants' War in 1525,
   through its time as a Mainz administrative seat, to its present
   use as a whisky castle.
 
@@ -30,8 +30,8 @@ content: >-
 
 
   The castle terrace rewards visitors with a wonderful panoramic view
-  over the Eichsfeld, the Leine Valley and the Ohmgebirge – on clear
-  days all the way to the Brocken in the Harz Mountains. Regional
+  over the Eichsfeld, the Leine Valley and the Ohmgebirge. On clear
+  days you can see all the way to the Brocken in the Harz Mountains. Regional
   specialities are served in the Restaurant 12HUNDERT9 and the Bistro
   Ringmauer. Those wishing to stay overnight will find stylishly
   furnished rooms in the boutique hotel.

--- a/content/attractions-en/draisine-eichsfeld.yml
+++ b/content/attractions-en/draisine-eichsfeld.yml
@@ -1,16 +1,16 @@
 name: 'Rail Bike Adventure Eichsfeld'
 slug: draisine-eichsfeld
-seoTitle: 'Rail Bike Adventure Eichsfeld – Tunnel Rides on Historic Tracks | Guesthouse in the Eichsfeld'
-seoDescription: 'Ride a rail bike through historic railway tunnels in the Eichsfeld – an unforgettable experience for the whole family. Just 20 km from Pension Volgenandt.'
+seoTitle: 'Rail Bike Adventure Eichsfeld: Tunnel Rides on Historic Tracks | Guesthouse in the Eichsfeld'
+seoDescription: 'Ride a rail bike through historic railway tunnels in the Eichsfeld, a great outing for the whole family. Just 20 km from Pension Volgenandt.'
 heroImage: /img/attractions/draisine-tunnel.webp
-heroImageAlt: 'Illuminated railway tunnel with old tracks and cycle path – rail bike route in the Eichsfeld'
+heroImageAlt: 'Illuminated railway tunnel with old tracks and cycle path on the rail bike route in the Eichsfeld'
 distanceKm: 20
 drivingMinutes: 25
 category: natur
 shortDescription: 'Pedal a rail bike through historic railway tunnels on disused tracks'
 intro: >-
-  A truly unique riding experience: pedal along old railway tracks
-  through the Eichsfeld – past forests, meadows and through
+  An unusual way to explore the region: pedal along old railway
+  tracks through the Eichsfeld, past forests, meadows and through
   impressive brick-vaulted tunnels. Ideal for families, couples
   and groups.
 content: >-
@@ -20,14 +20,14 @@ content: >-
   old track beds through the gentle rolling hills of the region.
 
 
-  The highlight of every tour is the historic brick-vaulted tunnels
-  – old railway tunnels that are now illuminated and open to
+  The highlight of every tour is the historic brick-vaulted tunnels,
+  old railway tunnels that are now illuminated and open to
   visitors. The dim light, cool breeze and long tunnel passages
   leave a lasting impression.
 
 
   The rail bikes typically seat two to four people and are easy to
-  operate – no special fitness or prior experience required. Children
+  operate. No special fitness or prior experience is required. Children
   can ride along and enjoy a journey that feels like stepping back
   in time.
 
@@ -36,7 +36,7 @@ content: >-
   and interests. Starting points generally have parking and small
   refreshment options.
 hostTip: >-
-  Book the rail bikes in advance – especially on weekends and
+  Book the rail bikes in advance. Especially on weekends and
   during school holidays, the popular spots fill up quickly.
   Allow some extra time to pause at the tunnel exits and take
   in the views.

--- a/content/attractions-en/eiscafe-san-remo.yml
+++ b/content/attractions-en/eiscafe-san-remo.yml
@@ -1,9 +1,9 @@
 name: 'Eiscafe San Remo'
 slug: eiscafe-san-remo
-seoTitle: 'Eiscafe San Remo Worbis – Homemade Ice Cream | Eichsfeld'
-seoDescription: 'Eiscafe San Remo in Worbis offers homemade ice cream, coffee and cake – just 9 km from our guesthouse in the Eichsfeld.'
+seoTitle: 'Eiscafe San Remo Worbis: Homemade Ice Cream | Eichsfeld'
+seoDescription: 'Eiscafe San Remo in Worbis offers homemade ice cream, coffee and cake, just 9 km from our guesthouse in the Eichsfeld.'
 heroImage: /img/attractions/eiscafe-san-remo-eisteller.webp
-heroImageAlt: 'Ice cream platter at Eiscafe San Remo – scoops, fruit, cream and wafer rolls'
+heroImageAlt: 'Ice cream platter at Eiscafe San Remo with scoops, fruit, cream and wafer rolls'
 distanceKm: 9
 drivingMinutes: 11
 category: kultur
@@ -11,39 +11,47 @@ shortDescription: 'Homemade ice cream, coffee and cake in the heart of Worbis'
 intro: >-
   Eiscafe San Remo in the centre of Worbis is known for its
   homemade ice cream flavours. The Grohmann family makes all
-  the ice cream varieties on site – a treat for young and old,
+  the ice cream varieties on site, a treat for young and old,
   especially after visiting the nearby bear park.
 content: >-
   Located in the shopping arcade on Lange Strasse, Eiscafe San Remo
   offers a wide selection of homemade ice cream in cones or cups.
-  Alongside the classic flavours, creative specialities like the
-  spaghetti ice cream platter are sure to surprise.
+  The Grohmann family makes all the flavours themselves, and the
+  owner learned the craft of ice cream making in Italy. Alongside
+  the classic flavours, creative specialities like the spaghetti ice
+  cream platter are sure to surprise.
 
 
-  The menu also has some more playful creations worth a look: several
-  spaghetti ice cream variations – the classic with strawberry sauce
-  and white chocolate, a banana or chocolate version, or a tongue-in-
-  cheek "Carbonara" style with eggnog and nuts – plus Tartufo with
-  chocolate sauce and coffee liqueur, colourful pizza ice cream, or
-  the fried-egg-look "Spiegelei" ice cream with apricots. For sharing,
-  there's the generously sized Coppa Mille Fiori for two.
+  The menu also has some more playful creations worth a look:
+  several spaghetti ice cream variations, the classic with
+  strawberry sauce and white chocolate, a banana or chocolate
+  version, or a tongue-in-cheek "Carbonara" style with eggnog and
+  nuts, plus Tartufo with chocolate sauce and coffee liqueur,
+  colourful pizza ice cream, or the fried-egg-look "Spiegelei" ice
+  cream with apricots. For sharing, there is the generously sized
+  Coppa Mille Fiori for two.
 
 
-  There is also coffee and cake, yoghurt creations, waffles and
-  light hot dishes. The atmosphere is cosy and the service friendly
-  – no wonder the cafe has a 4.7 out of 5 star rating on Google.
+  We have been visiting San Remo ourselves for a long time, since
+  our children were toddlers, and we still stop by regularly today.
+  Our favourite is the blueberry cup, made with fresh blueberries
+  and plenty of cream. In summer, we also regularly bring our own
+  berries from the guesthouse garden, which are then turned into ice
+  cream there.
+
+
+  There is also coffee and cake, yoghurt creations and waffles. The
+  atmosphere is cosy and the service friendly.
 
 
   The cafe is located at Lange Strasse 17 in Leinefelde-Worbis.
-  Opening hours are Monday and Friday 12pm-6pm, Tuesday to Thursday
-  9am-6pm, and Sunday 1pm-7pm; closed on Saturdays.
 
 
   San Remo is the perfect stop during a stroll through Worbis or
   after a visit to the Alternative Bear Park, which is just a short
   walk away.
 hostTip: >-
-  Try the "Carbonara" spaghetti ice cream – the playful version with
+  Try the "Carbonara" spaghetti ice cream. The playful version with
   eggnog and nuts is guaranteed to spark conversation at the family
   table. Combine your visit with the Bear Park Worbis, just a few
   minutes' walk away.
@@ -52,7 +60,7 @@ website: 'https://sanremo-worbis.de/'
 additionalWebsites:
   - label: 'Instagram'
     url: 'https://www.instagram.com/eiscafe.san.remo/'
-  - label: 'Google Maps'
+  - label: 'Google Reviews'
     url: 'https://www.google.com/maps/search/Eiscafé+San+Remo+Worbis'
 coordinates:
   lat: 51.4088

--- a/content/attractions-en/grenzlandmuseum.yml
+++ b/content/attractions-en/grenzlandmuseum.yml
@@ -1,7 +1,7 @@
 name: 'Eichsfeld Border Museum'
 slug: grenzlandmuseum
 seoTitle: 'Eichsfeld Border Museum | Guesthouse near Teistungen'
-seoDescription: 'The Eichsfeld Border Museum in Teistungen documents the history of the inner-German border – just 16 km from our guesthouse.'
+seoDescription: 'The Eichsfeld Border Museum in Teistungen documents the history of the inner-German border, just 16 km from our guesthouse.'
 heroImage: ''
 heroImageAlt: ''
 distanceKm: 16
@@ -21,7 +21,7 @@ content: >-
   zone up until the opening in 1989.
 
 
-  The centrepiece is the Border Trail – a 6-kilometre circular route
+  The centrepiece is the Border Trail, a 6-kilometre circular route
   with 24 stations and original border installations: watchtowers,
   signal fences, vehicle barriers and an accessible observation
   bunker. The former death strip is now part of the Green Belt, a
@@ -32,7 +32,7 @@ content: >-
   On Saturdays at 2 pm there is a public guided tour along the
   Border Trail.
 hostTip: >-
-  Allow at least 3 hours – the exhibition and the Border Trail
+  Allow at least 3 hours. The exhibition and the Border Trail
   together are particularly moving. Sturdy footwear is recommended
   for the outdoor trail.
 bestTimeToVisit: 'Year-round, dry weather recommended for the Border Trail'

--- a/content/attractions-en/harz.yml
+++ b/content/attractions-en/harz.yml
@@ -1,13 +1,13 @@
 name: 'Harz Mountains'
 slug: harz
-seoTitle: 'Harz Mountains – Day Trip from the Guesthouse in the Eichsfeld'
+seoTitle: 'Harz Mountains: Day Trip from the Guesthouse in the Eichsfeld'
 seoDescription: 'The Harz Mountains with the Brocken peak are just 40 km from our guesthouse. Brocken Railway, hiking trails and stalactite caves as a day trip.'
 heroImage: ''
 heroImageAlt: ''
 distanceKm: 40
 drivingMinutes: 40
 category: natur
-shortDescription: "Brocken peak, Brocken Railway and hiking trails – Germany's northernmost low mountain range"
+shortDescription: "Brocken peak, Brocken Railway and hiking trails in Germany's northernmost low mountain range"
 intro: >-
   The Harz Mountains lie just around 40 kilometres north of our
   guesthouse and are perfect for a day trip. With the Brocken peak
@@ -15,7 +15,7 @@ intro: >-
   of hiking trails, the Harz offers pure nature.
 content: >-
   Via Bad Lauterberg or Bad Sachsa you can reach the southern Harz
-  in less than an hour. The highlight is the Brocken – at 1,141
+  in less than an hour. The highlight is the Brocken, at 1,141
   metres the highest peak in northern Germany. You can reach the
   summit on foot or aboard the steam-powered Brocken Railway, one
   of the largest narrow-gauge railways in Germany.
@@ -24,7 +24,7 @@ content: >-
   Harz National Park protects 247 square kilometres of unique
   mountain landscape with moors, spruce forests and rare animal
   species. Over 8,000 kilometres of marked hiking trails lead
-  through the region – from leisurely walks to challenging summit
+  through the region, from leisurely walks to challenging summit
   tours.
 
 
@@ -34,7 +34,7 @@ content: >-
   you to explore.
 hostTip: >-
   Take the Brocken Railway from Wernigerode to the summit and hike
-  back down via the Goetheweg trail – that way you can experience
+  back down via the Goetheweg trail. That way you can experience
   both in one day.
 bestTimeToVisit: 'June to October, dress warmly on the Brocken'
 website: 'https://www.harzinfo.de'

--- a/content/attractions-en/seeburger-see.yml
+++ b/content/attractions-en/seeburger-see.yml
@@ -1,13 +1,13 @@
 name: 'Lake Seeburger See'
 slug: seeburger-see
-seoTitle: 'Seeburger See – the Eye of the Eichsfeld | Guesthouse in the Eichsfeld'
-seoDescription: 'Seeburger See – the Eye of the Eichsfeld – is just 25 km from our guesthouse. Swimming, boating and nature experiences.'
+seoTitle: 'Seeburger See, the Eye of the Eichsfeld | Guesthouse in the Eichsfeld'
+seoDescription: 'Seeburger See, known as the Eye of the Eichsfeld, is just 25 km from our guesthouse. Swimming, boating and nature experiences.'
 heroImage: /img/attractions/seeburger-see-seerosen.webp
-heroImageAlt: 'Seeburger See – water lilies on the still lake under summer clouds'
+heroImageAlt: 'Seeburger See, water lilies on the still lake under summer clouds'
 distanceKm: 25
 drivingMinutes: 30
 category: natur
-shortDescription: '"The Eye of the Eichsfeld" – swimming, boating and nature'
+shortDescription: '"The Eye of the Eichsfeld": swimming, boating and nature'
 intro: >-
   Seeburger See is affectionately known as "the Eye of the Eichsfeld".
   At around 88 hectares it is the largest natural lake in southern
@@ -32,8 +32,8 @@ content: >-
   course.
 hostTip: >-
   On a warm summer day it is ideal for swimming. Take a pedal boat
-  and explore the lake from the water – especially beautiful in the
-  evening sun.
+  and explore the lake from the water. It is especially beautiful
+  in the evening sun.
 bestTimeToVisit: 'May to September for swimming, spring and autumn for birdwatching'
 website: 'https://www.google.com/maps/search/Seeburger+See'
 coordinates:

--- a/content/attractions-en/sielmann-stiftung.yml
+++ b/content/attractions-en/sielmann-stiftung.yml
@@ -1,9 +1,9 @@
 name: 'Heinz Sielmann Foundation – Gut Herbigshagen'
 slug: sielmann-stiftung
-seoTitle: 'Heinz Sielmann Foundation Gut Herbigshagen – Experience Nature in the Eichsfeld'
-seoDescription: 'The Gut Herbigshagen nature experience grounds of the Heinz Sielmann Foundation offer wildlife watching, hiking trails and sweeping Eichsfeld panoramas – just 20 km from the guesthouse.'
+seoTitle: 'Heinz Sielmann Foundation Gut Herbigshagen: Nature Watching in the Eichsfeld'
+seoDescription: 'The Gut Herbigshagen nature experience grounds of the Heinz Sielmann Foundation offer wildlife watching, hiking trails and sweeping Eichsfeld panoramas, just 20 km from the guesthouse.'
 heroImage: /img/attractions/sielmann-stiftung-panorama.webp
-heroImageAlt: 'Sweeping Eichsfeld panorama from Gut Herbigshagen of the Heinz Sielmann Foundation – fields, forests and hills under blue skies'
+heroImageAlt: 'Sweeping Eichsfeld panorama from Gut Herbigshagen of the Heinz Sielmann Foundation, with fields, forests and hills under blue skies'
 distanceKm: 20
 drivingMinutes: 22
 category: natur
@@ -12,21 +12,22 @@ intro: >-
   The Gut Herbigshagen nature experience grounds of the Heinz Sielmann
   Foundation are situated on an expansive hilltop ridge south of
   Duderstadt. From here you can enjoy a breathtaking panoramic view
-  over the Eichsfeld – and the chance to observe free-roaming
+  over the Eichsfeld, plus the chance to observe free-roaming
   wildlife up close.
 content: >-
   Heinz Sielmann, the legendary nature documentary filmmaker, turned
   Gut Herbigshagen into a vibrant nature experience. On the expansive
   grounds, European bison, Przewalski's horses, Konik horses and
-  various cattle breeds graze on large open pastures – in their
+  various cattle breeds graze on large open pastures, in their
   natural state and visible from the visitor paths without any fences
   in between.
 
 
   The viewpoint hill on the grounds offers one of the finest panoramas
   in the entire Eichsfeld: fields, forests, villages and the gentle
-  hill chains of the region spread out all around – on clear days
-  extending far into the Harz Mountains and the Thuringian Eichsfeld.
+  hill chains of the region spread out all around. On clear days
+  the view extends far into the Harz Mountains and the Thuringian
+  Eichsfeld.
 
 
   Well-maintained hiking trails lead across the grounds, past wildlife,
@@ -37,10 +38,10 @@ content: >-
 
 
   The grounds are accessible year-round and are particularly suited
-  to peaceful nature experiences – ideal after an active day in the
+  to peaceful nature experiences, ideal after an active day in the
   surrounding area.
 hostTip: >-
-  Come early in the morning or in the late afternoon – that is when
+  Come early in the morning or in the late afternoon, when
   the wildlife is most active. Bring binoculars and sturdy shoes for
   the field paths. The view from the hilltop at sunset is especially
   impressive.

--- a/content/attractions-en/skywalk-sonnenstein.yml
+++ b/content/attractions-en/skywalk-sonnenstein.yml
@@ -1,7 +1,7 @@
 name: 'Skywalk Sonnenstein'
 slug: skywalk-sonnenstein
 seoTitle: 'Skywalk Sonnenstein | Guesthouse near Skywalk'
-seoDescription: 'Experience the Skywalk Sonnenstein near Holungen – a spectacular viewing platform. Just 14 km from our guesthouse in the Eichsfeld.'
+seoDescription: 'Visit the Skywalk Sonnenstein near Holungen, a spectacular viewing platform. Just 14 km from our guesthouse in the Eichsfeld.'
 heroImage: /img/attractions/sonnenstein-skulptur-panorama.webp
 heroImageAlt: 'Wooden giant sculpture at Sonnenstein with sweeping panoramic view over the Eichsfeld in winter'
 distanceKm: 14
@@ -9,13 +9,13 @@ drivingMinutes: 16
 category: natur
 shortDescription: 'Spectacular viewing platform with panoramic views'
 intro: >-
-  The Skywalk at Sonnenstein near Holungen offers an unforgettable
-  nature experience. The cantilevered viewing platform extends beyond
+  The Skywalk at Sonnenstein near Holungen offers a memorable outing
+  in nature. The cantilevered viewing platform extends beyond
   the cliff edge and rewards brave visitors with a breathtaking
   panorama over the Eichsfeld.
 content: >-
   About 14 kilometres from our guesthouse, the Skywalk at Sonnenstein
-  awaits – one of the most spectacular viewing platforms in the
+  awaits, one of the most spectacular viewing platforms in the
   Eichsfeld. The steel structure extends several metres beyond the
   cliff edge, offering a unique view into the depths and across the
   wide landscape.
@@ -28,7 +28,7 @@ content: >-
 
 
   Besides the Skywalk, a visit to the nearby limestone quarry is also
-  worthwhile – a small lake has formed there. The combination of
+  worthwhile. A small lake has formed there. The combination of
   geology, nature and modern architecture makes Sonnenstein a
   distinctive destination.
 

--- a/content/attractions-en/vitalpark-heiligenstadt.yml
+++ b/content/attractions-en/vitalpark-heiligenstadt.yml
@@ -1,7 +1,7 @@
 name: 'Heilbad Heiligenstadt & Vitalpark'
 slug: vitalpark-heiligenstadt
-seoTitle: 'Heilbad Heiligenstadt – Old Town, Spa Park & Vitalpark | Guesthouse in the Eichsfeld'
-seoDescription: 'Heilbad Heiligenstadt – the over 1,000-year-old county town of the Eichsfeld with historic old town, spa park, literary museum and Vitalpark. Just 15 km from our guesthouse.'
+seoTitle: 'Heilbad Heiligenstadt: Old Town, Spa Park & Vitalpark | Guesthouse in the Eichsfeld'
+seoDescription: 'Heilbad Heiligenstadt, the over 1,000-year-old county town of the Eichsfeld, has a historic old town, spa park, literary museum and Vitalpark. Just 15 km from our guesthouse.'
 heroImage: /img/attractions/vitalpark-heiligenstadt.webp
 heroImageAlt: "St Mary's Church with twin towers and baroque cloister garden in Heilbad Heiligenstadt"
 distanceKm: 15
@@ -12,7 +12,7 @@ intro: >-
   Heilbad Heiligenstadt, the county town of the Eichsfeld, is also
   known as the "Town of Ten Towers". Half-timbered houses, three
   Gothic churches and a charming pedestrian zone invite you to
-  explore – just 15 minutes from our guesthouse.
+  explore, just 15 minutes from our guesthouse.
 content: >-
   Along Wilhelmstrasse, the roughly one-kilometre-long pedestrian
   zone, small cafes, restaurants and shops line up side by side.
@@ -38,13 +38,13 @@ content: >-
 
   A stroll through town pairs perfectly with a visit to the Vitalpark:
   thermal baths, eight saunas ranging from an earth sauna to a Finnish
-  sauna, a rasul, sauna garden and tower bar – ideal for relaxing
+  sauna, a rasul, sauna garden and tower bar, ideal for relaxing
   after an active day.
 hostTip: >-
   Our tip: stroll through the old town in the morning and relax
   in the Vitalpark in the afternoon. If you are staying with us
-  over Easter, do not miss the Palm Sunday procession – a UNESCO
-  cultural heritage event and a truly special experience.
+  over Easter, do not miss the Palm Sunday procession, recognised
+  as a UNESCO cultural heritage event.
 bestTimeToVisit: 'Year-round'
 website: 'https://www.heilbad-heiligenstadt.de'
 additionalWebsites:

--- a/content/attractions-en/wartburg.yml
+++ b/content/attractions-en/wartburg.yml
@@ -1,13 +1,13 @@
 name: 'Wartburg Castle'
 slug: wartburg
 seoTitle: 'Wartburg Castle near Eisenach | Guesthouse in the Eichsfeld'
-seoDescription: 'Visit Wartburg Castle – a UNESCO World Heritage Site near Eisenach. About 55 km from our guesthouse in the Eichsfeld.'
+seoDescription: 'Visit Wartburg Castle, a UNESCO World Heritage Site near Eisenach. About 55 km from our guesthouse in the Eichsfeld.'
 heroImage: /img/attractions/wartburg.webp
-heroImageAlt: 'Wartburg Castle near Eisenach – UNESCO World Heritage Site on a cliff above the Thuringian Forest'
+heroImageAlt: 'Wartburg Castle near Eisenach, a UNESCO World Heritage Site on a cliff above the Thuringian Forest'
 distanceKm: 55
 drivingMinutes: 55
 category: kultur
-shortDescription: 'UNESCO World Heritage Site – where Luther translated the New Testament'
+shortDescription: 'UNESCO World Heritage Site where Luther translated the New Testament'
 intro: >-
   Wartburg Castle near Eisenach is one of the most famous castles
   in Germany and has been a UNESCO World Heritage Site since 1999.
@@ -16,7 +16,7 @@ intro: >-
 content: >-
   About 55 kilometres from our guesthouse, Wartburg Castle sits
   majestically on a cliff above Eisenach. The over 900-year-old
-  castle is closely linked to German history – from the minnesingers
+  castle is closely linked to German history, from the minnesingers
   around 1200 and Saint Elizabeth to Martin Luther's Bible translation
   in 1521/22.
 
@@ -31,7 +31,7 @@ content: >-
   Forest. The castle grounds and courtyards are freely accessible,
   while the museum and historic rooms can be toured.
 hostTip: >-
-  Plan your visit on a weekday – it can get very crowded at weekends.
+  Plan your visit on a weekday. It can get very crowded at weekends.
   The 30-minute walk from the car park through the forest is already
   an experience in itself.
 bestTimeToVisit: 'May to October, fewer visitors on weekdays'

--- a/content/attractions-teaser/index.yml
+++ b/content/attractions-teaser/index.yml
@@ -1,7 +1,7 @@
 items:
   - name: 'Alternativer Bärenpark Worbis'
     slug: baerenpark-worbis
-    shortDescription: 'Erleben Sie Braun- und Schwarzbären in naturnahen Gehegen'
+    shortDescription: 'Braun- und Schwarzbären in naturnahen Gehegen'
     image: /img/attractions/baerenpark-worbis.webp
     imageAlt: 'Braunbär im Alternativen Bärenpark Worbis'
     distanceKm: 6

--- a/content/attractions/baerenpark-worbis.yml
+++ b/content/attractions/baerenpark-worbis.yml
@@ -19,7 +19,7 @@ content: >-
 
 
   Der Park wurde als Auffangstation für Bären aus schlechter Haltung
-  gegründet und bietet Besuchern einen einzigartigen Einblick in das
+  gegründet und bietet Besuchern einen nahen Einblick in das
   Leben dieser faszinierenden Tiere. Ein Rundweg führt durch den
   gesamten Park, vorbei an Beobachtungspunkten und Informationstafeln.
 
@@ -30,8 +30,8 @@ content: >-
 
 
   Der Bärenpark setzt sich aktiv für den Tierschutz ein und informiert
-  über die Problematik privater Wildtierhaltung. Ein Besuch ist nicht
-  nur ein schönes Erlebnis, sondern unterstützt auch eine wichtige Sache.
+  über die Problematik privater Wildtierhaltung. Ein Besuch ist ein
+  schönes Erlebnis und unterstützt gleichzeitig eine wichtige Sache.
 hostTip: >-
   Kommen Sie am besten morgens, wenn die Bären am aktivsten sind.
   Der Rundweg dauert etwa 1-2 Stunden. Nehmen Sie festes Schuhwerk

--- a/content/attractions/baumkronenpfad-hainich.yml
+++ b/content/attractions/baumkronenpfad-hainich.yml
@@ -15,14 +15,14 @@ intro: >-
   durch die Baumkronen.
 content: >-
   Etwa 54 Kilometer südwestlich von unserer Pension liegt der
-  Nationalpark Hainich – ein einzigartiges Naturparadies, das seit
+  Nationalpark Hainich, ein Naturparadies, das seit
   2011 zum UNESCO-Weltnaturerbe gehört. Hier wächst der größte
   zusammenhängende Laubwald Deutschlands weitgehend ungestört.
 
 
   Das Highlight für Besucher ist der Baumkronenpfad mit seinem 44
   Meter hohen Aussichtsturm. Der 540 Meter lange Pfad führt
-  barrierefrei durch die verschiedenen Schichten des Waldes – vom
+  barrierefrei durch die verschiedenen Schichten des Waldes, vom
   Waldboden bis hinauf in die Baumkronen. Von oben eröffnet sich
   ein faszinierender Blick über das endlose Laubdach.
 
@@ -35,7 +35,7 @@ content: >-
 
   Besonders im Frühling, wenn der Waldboden mit Bärlauch und
   Buschwindröschen bedeckt ist, und im Herbst mit seiner leuchtenden
-  Laubfärbung ist der Hainich ein unvergessliches Naturerlebnis.
+  Laubfärbung ist der Hainich ein besonderes Naturerlebnis.
 hostTip: >-
   Planen Sie für den Hainich einen ganzen Tag ein. Kombinieren
   Sie den Baumkronenpfad mit einer Wanderung auf dem Feensteig

--- a/content/attractions/brotmuseum-ebergotzen.yml
+++ b/content/attractions/brotmuseum-ebergotzen.yml
@@ -10,7 +10,7 @@ category: kultur
 shortDescription: '10.000 Jahre Brotgeschichte auf einem historischen Gutshof mit Windmühle'
 intro: >-
   Das Europäische Brotmuseum in Ebergötzen erzählt auf einem
-  weitläufigen historischen Gutshof die Geschichte des Brotes –
+  weitläufigen historischen Gutshof die Geschichte des Brotes,
   von der Steinzeit bis heute. Mit Windmühle, Kräutergarten
   und lebendigen Ausstellungen ein Ausflug für die ganze Familie.
 content: >-

--- a/content/attractions/burg-bodenstein.yml
+++ b/content/attractions/burg-bodenstein.yml
@@ -27,7 +27,7 @@ content: >-
 
   Das Burgcafé lädt mit hausgemachtem Kuchen und regionalen Spezialitäten
   zum Verweilen ein. Besonders empfehlenswert ist die Terrasse mit Blick
-  ins Tal – ein herrlicher Ort für eine Kaffeepause nach der Besichtigung.
+  ins Tal, ein herrlicher Ort für eine Kaffeepause nach der Besichtigung.
 
 
   Rund um die Burg führen mehrere Wanderwege durch die bewaldeten Hänge.

--- a/content/attractions/burg-hanstein.yml
+++ b/content/attractions/burg-hanstein.yml
@@ -11,7 +11,7 @@ shortDescription: 'Eine der größten Burgruinen Mitteldeutschlands mit Panorama
 intro: >-
   Die Burgruine Hanstein bei Bornhagen zählt zu den größten und
   eindrucksvollsten Burgruinen in Mitteldeutschland. Von den mächtigen
-  Mauern genießt man einen unvergesslichen Panoramablick über das Werratal
+  Mauern genießt man einen weiten Panoramablick über das Werratal
   und das Eichsfeld.
 content: >-
   Nur 40 Kilometer von unserer Pension erhebt sich die Burgruine Hanstein
@@ -38,8 +38,8 @@ content: >-
 hostTip: >-
   Besuchen Sie die Burg am besten bei klarem Wetter für den
   besten Panoramablick. Im Sommer finden auf der Burg regelmäßig
-  Veranstaltungen und Mittelalterfeste statt – fragen Sie uns nach
-  aktuellen Terminen.
+  Veranstaltungen und Mittelalterfeste statt. Fragen Sie uns gern
+  nach aktuellen Terminen.
 bestTimeToVisit: 'Frühling bis Herbst bei klarem Wetter'
 website: 'https://www.burgruine-hanstein.de'
 coordinates:

--- a/content/attractions/burg-scharfenstein.yml
+++ b/content/attractions/burg-scharfenstein.yml
@@ -10,14 +10,14 @@ category: kultur
 shortDescription: 'Mittelalterliche Burg mit Whiskywelt, Burghotel und Panoramablick'
 intro: >-
   Burg Scharfenstein bei Beuren verbindet über 800 Jahre
-  Geschichte mit einem einzigartigen Whisky-Erlebnis. In der
+  Geschichte mit einem besonderen Whisky-Erlebnis. In der
   Whiskywelt reift der preisgekrönte Nine Springs Single Malt
-  Whisky – hergestellt mit dem weichen Quellwasser des Eichsfelds.
+  Whisky, hergestellt mit dem weichen Quellwasser des Eichsfelds.
 content: >-
   Nur etwa 10 Kilometer von unserer Pension entfernt thront
   Burg Scharfenstein auf einem Felssporn über dem Leinetal. Die
   Burg wurde um 1200 von den Grafen von Gleichen erbaut und
-  blickt auf eine bewegte Geschichte zurück – von der Bauernkriegs-
+  blickt auf eine bewegte Geschichte zurück: von der Bauernkriegs-
   Zerstörung 1525 über die Zeit als Mainzer Amtssitz bis zur
   heutigen Nutzung als Whisky-Burg.
 
@@ -31,7 +31,7 @@ content: >-
 
 
   Die Burgterrasse belohnt mit einem herrlichen Panoramablick
-  über das Eichsfeld, das Leinetal und das Ohmgebirge – bei klarer
+  über das Eichsfeld, das Leinetal und das Ohmgebirge, bei klarer
   Sicht bis zum Brocken im Harz. Im Restaurant 12HUNDERT9 und
   im Bistro Ringmauer werden regionale Spezialitäten serviert.
   Wer übernachten möchte, findet im Boutique-Hotel stilvoll

--- a/content/attractions/draisine-eichsfeld.yml
+++ b/content/attractions/draisine-eichsfeld.yml
@@ -1,7 +1,7 @@
 name: 'Draisinen-Erlebnis Eichsfeld'
 slug: draisine-eichsfeld
 seoTitle: 'Draisinen-Erlebnis Eichsfeld – Tunnelfahrt auf alten Gleisen | Pension im Eichsfeld'
-seoDescription: 'Mit der Draisine durch historische Bahntunnel im Eichsfeld – ein unvergessliches Erlebnis für die ganze Familie. Nur 20 km von der Pension Volgenandt.'
+seoDescription: 'Mit der Draisine durch historische Bahntunnel im Eichsfeld, ein schönes Erlebnis für die ganze Familie. Nur 20 km von der Pension Volgenandt.'
 heroImage: /img/attractions/draisine-tunnel.webp
 heroImageAlt: 'Beleuchteter Bahntunnel mit alten Gleisen und Radweg – Draisinen-Strecke im Eichsfeld'
 distanceKm: 20
@@ -21,15 +21,15 @@ content: >-
   der Region.
 
 
-  Highlight jeder Tour sind die historischen Backsteingewölbe –
+  Highlight jeder Tour sind die historischen Backsteingewölbe,
   alte Eisenbahntunnel, die heute beleuchtet und für Besucher
   geöffnet sind. Das gedämpfte Licht, der kühle Fahrtwind und
   die langen Tunnelröhren hinterlassen einen bleibenden Eindruck.
 
 
   Die Draisinen fassen meist zwei bis vier Personen und sind
-  einfach zu bedienen – keine besondere Fitness oder Vorkenntnisse
-  erforderlich. Kinder können mitfahren und erleben eine
+  einfach zu bedienen. Besondere Fitness oder Vorkenntnisse sind
+  nicht nötig. Kinder können mitfahren und erleben eine
   Reise wie aus einer anderen Zeit.
 
 

--- a/content/attractions/eiscafe-san-remo.yml
+++ b/content/attractions/eiscafe-san-remo.yml
@@ -1,7 +1,7 @@
 name: 'Eiscafé San Remo'
 slug: eiscafe-san-remo
 seoTitle: 'Eiscafé San Remo Worbis – hausgemachtes Eis | Eichsfeld'
-seoDescription: 'Das Eiscafé San Remo in Worbis bietet hausgemachtes Eis, Kaffee und Kuchen – nur 9 km von unserer Pension im Eichsfeld.'
+seoDescription: 'Das Eiscafé San Remo in Worbis bietet hausgemachtes Eis, Kaffee und Kuchen und liegt nur 9 km von unserer Pension im Eichsfeld entfernt.'
 heroImage: /img/attractions/eiscafe-san-remo-eisteller.webp
 heroImageAlt: 'Eisbecher-Teller im Eiscafé San Remo – Kugeln, Früchte, Sahne und Waffelröllchen'
 distanceKm: 9
@@ -11,41 +11,46 @@ shortDescription: 'Hausgemachtes Eis, Kaffee und Kuchen im Herzen von Worbis'
 intro: >-
   Das Eiscafé San Remo in der Worbiser Innenstadt ist bekannt für
   seine hausgemachten Eissorten. Familie Grohmann stellt alle
-  Eisvariationen selbst her – ein Genuss für Groß und Klein,
+  Eisvariationen selbst her. Das schmeckt Groß und Klein,
   besonders nach einem Besuch im nahen Bärenpark.
 content: >-
   In der Einkaufspassage an der Langen Straße gelegen, bietet das
   Eiscafé San Remo eine große Auswahl an selbst hergestelltem Eis
-  in der Waffel oder im Becher. Neben den klassischen Eissorten
-  überraschen kreative Spezialitäten wie der Spaghettieisteller.
+  in der Waffel oder im Becher. Familie Grohmann stellt alle
+  Eissorten selbst her, der Inhaber hat das Eismachen in Italien
+  gelernt. Neben den klassischen Sorten überraschen kreative
+  Spezialitäten wie der Spaghettieisteller.
 
 
   Auf der Eiskarte lohnt sich ein Blick auf die ausgefalleneren
-  Kreationen: gleich mehrere Spaghetti-Eis-Varianten – klassisch mit
+  Kreationen: gleich mehrere Spaghetti-Eis-Varianten, klassisch mit
   Erdbeersoße und weißer Schokolade, als Bananen- oder Schokoversion,
-  oder augenzwinkernd als „Carbonara“ mit Eierlikör und Nüssen –,
-  dazu Tartufo mit Schokosoße und Kaffeelikör, buntes Pizza-Eis oder
-  das Spiegelei-Eis mit Aprikosen. Wer es opulent mag, teilt sich zu
+  oder augenzwinkernd als „Carbonara“ mit Eierlikör und Nüssen, dazu
+  Tartufo mit Schokosoße und Kaffeelikör, buntes Pizza-Eis oder das
+  Spiegelei-Eis mit Aprikosen. Wer es opulent mag, teilt sich zu
   zweit die Coppa Mille Fiori.
 
 
-  Dazu gibt es Kaffee und Kuchen, Joghurt-Kreationen, Waffeln
-  und kleine warme Gerichte. Die Atmosphäre ist gemütlich
-  und der Service freundlich –
-  kein Wunder, dass das Café bei Google 4,7 von 5 Sternen hat.
+  Wir besuchen das San Remo selbst schon lange, seit unsere Kinder
+  im Eisalter waren, und kommen bis heute regelmäßig vorbei. Unser
+  Favorit ist der Heidelbeerbecher, mit frischen Heidelbeeren und
+  viel Sahne. Im Sommer bringen wir außerdem regelmäßig unsere
+  eigenen Beeren aus dem Garten der Pension vorbei, aus denen dort
+  Eis gemacht wird.
+
+
+  Dazu gibt es Kaffee und Kuchen, Joghurt-Kreationen und Waffeln.
+  Die Atmosphäre ist gemütlich und der Service freundlich.
 
 
   Das Café liegt in der Langen Straße 17 in Leinefelde-Worbis.
-  Geöffnet ist montags und freitags von 12 bis 18 Uhr, dienstags
-  bis donnerstags von 9 bis 18 Uhr sowie sonntags von 13 bis 19 Uhr;
-  samstags bleibt es geschlossen.
 
 
   Das San Remo eignet sich perfekt als Zwischenstopp bei einem
   Bummel durch Worbis oder nach einem Besuch im Alternativen
   Bärenpark, der nur wenige Gehminuten entfernt liegt.
 hostTip: >-
-  Probieren Sie das Spaghetti-Eis „Carbonara“ – die humorvolle
+  Probieren Sie das Spaghetti-Eis „Carbonara”. Die humorvolle
   Variante mit Eierlikör und Nüssen sorgt garantiert für Gesprächsstoff
   am Familientisch. Kombinieren Sie den Besuch mit dem Bärenpark
   Worbis, der nur wenige Minuten zu Fuß entfernt ist.
@@ -54,7 +59,7 @@ website: 'https://sanremo-worbis.de/'
 additionalWebsites:
   - label: 'Instagram'
     url: 'https://www.instagram.com/eiscafe.san.remo/'
-  - label: 'Google Maps'
+  - label: 'Google Bewertungen'
     url: 'https://www.google.com/maps/search/Eiscafé+San+Remo+Worbis'
 coordinates:
   lat: 51.4088

--- a/content/attractions/grenzlandmuseum.yml
+++ b/content/attractions/grenzlandmuseum.yml
@@ -25,7 +25,7 @@ content: >-
   Rundweg mit 24 Stationen und originalen Grenzanlagen:
   Wachtürme, Signalzäune, Fahrzeugsperren und ein begehbarer
   Beobachtungsbunker. Der ehemalige Todesstreifen ist heute
-  Teil des Grünen Bandes, eines einzigartigen Naturstreifens
+  Teil des Grünen Bandes, eines langen Naturstreifens
   entlang der einstigen Grenze.
 
 

--- a/content/attractions/harz.yml
+++ b/content/attractions/harz.yml
@@ -23,7 +23,7 @@ content: >-
 
 
   Der Nationalpark Harz schützt auf 247 Quadratkilometern
-  eine einzigartige Berglandschaft mit Mooren, Fichtenwäldern
+  eine vielfältige Berglandschaft mit Mooren, Fichtenwäldern
   und seltenen Tierarten. Über 8.000 Kilometer markierte
   Wanderwege führen durch die Region – von gemütlichen
   Spaziergängen bis zu anspruchsvollen Gipfeltouren.

--- a/content/attractions/seeburger-see.yml
+++ b/content/attractions/seeburger-see.yml
@@ -32,8 +32,8 @@ content: >-
   und einen Minigolfplatz.
 hostTip: >-
   An einem warmen Sommertag ideal zum Baden. Nehmen Sie ein
-  Tretboot und erkunden Sie den See vom Wasser aus – besonders
-  schön in der Abendsonne.
+  Tretboot und erkunden Sie den See vom Wasser aus. Besonders
+  schön ist das in der Abendsonne.
 bestTimeToVisit: 'Mai bis September zum Baden, Frühling und Herbst zur Vogelbeobachtung'
 website: 'https://www.google.com/maps/search/Seeburger+See'
 coordinates:

--- a/content/attractions/sielmann-stiftung.yml
+++ b/content/attractions/sielmann-stiftung.yml
@@ -1,7 +1,7 @@
 name: 'Heinz Sielmann Stiftung – Gut Herbigshagen'
 slug: sielmann-stiftung
 seoTitle: 'Heinz Sielmann Stiftung Gut Herbigshagen – Natur erleben im Eichsfeld'
-seoDescription: 'Das Naturerlebnisgelände Gut Herbigshagen der Heinz Sielmann Stiftung bietet Wildtierbeobachtung, Wanderwege und weite Eichsfeld-Panoramen – nur 20 km von der Pension.'
+seoDescription: 'Das Naturerlebnisgelände Gut Herbigshagen der Heinz Sielmann Stiftung bietet Wildtierbeobachtung, Wanderwege und weite Eichsfeld-Panoramen, nur 20 km von der Pension.'
 heroImage: /img/attractions/sielmann-stiftung-panorama.webp
 heroImageAlt: 'Weites Eichsfeld-Panorama vom Gut Herbigshagen der Heinz Sielmann Stiftung – Felder, Wälder und Hügel unter blauem Himmel'
 distanceKm: 20
@@ -11,9 +11,9 @@ shortDescription: 'Wildtiere beobachten und weite Eichsfeld-Panoramen genießen 
 intro: >-
   Das Naturerlebnisgelände Gut Herbigshagen der Heinz Sielmann
   Stiftung liegt auf einem weitläufigen Höhenzug südlich von
-  Duderstadt. Von hier aus bietet sich ein atemberaubender
-  Panoramablick über das Eichsfeld – und die Möglichkeit,
-  freilebende Wildtiere aus nächster Nähe zu beobachten.
+  Duderstadt. Von hier aus bietet sich ein weiter
+  Panoramablick über das Eichsfeld, und Sie können
+  freilebende Wildtiere aus nächster Nähe beobachten.
 content: >-
   Heinz Sielmann, der legendäre Naturdokumentarfilmer, hat
   Gut Herbigshagen zu einem lebendigen Naturerlebnis gemacht.
@@ -26,8 +26,8 @@ content: >-
   Der Aussichtshügel auf dem Gelände bietet einen der
   schönsten Panoramablicke im gesamten Eichsfeld: Felder,
   Wälder, Dörfer und die sanften Hügelketten der Region
-  breiten sich ringsum aus – an klaren Tagen bis weit in den
-  Harz und das thüringische Eichsfeld hinein.
+  breiten sich ringsum aus, an klaren Tagen reicht der Blick
+  bis weit in den Harz und das thüringische Eichsfeld.
 
 
   Gut ausgebaute Wanderwege führen über das Gelände, vorbei
@@ -38,10 +38,10 @@ content: >-
 
 
   Das Gelände ist ganzjährig zugänglich und eignet sich
-  besonders für ruhige Naturerlebnisse – ideal nach einem
+  besonders für ruhige Naturerlebnisse. Ideal nach einem
   aktiven Tag in der Umgebung.
 hostTip: >-
-  Kommen Sie früh morgens oder am späten Nachmittag – dann
+  Kommen Sie früh morgens oder am späten Nachmittag, dann
   sind die Wildtiere am aktivsten. Nehmen Sie ein Fernglas mit
   und feste Schuhe für die Feldwege. Der Blick vom Aussichtshügel
   bei Sonnenuntergang ist besonders beeindruckend.

--- a/content/attractions/skywalk-sonnenstein.yml
+++ b/content/attractions/skywalk-sonnenstein.yml
@@ -1,7 +1,7 @@
 name: 'Skywalk Sonnenstein'
 slug: skywalk-sonnenstein
 seoTitle: 'Skywalk Sonnenstein | Pension nahe Skywalk'
-seoDescription: 'Erleben Sie den Skywalk Sonnenstein bei Holungen – eine spektakuläre Aussichtsplattform. Nur 14 km von unserer Pension im Eichsfeld.'
+seoDescription: 'Der Skywalk Sonnenstein bei Holungen ist eine spektakuläre Aussichtsplattform, nur 14 km von unserer Pension im Eichsfeld.'
 heroImage: /img/attractions/sonnenstein-skulptur-panorama.webp
 heroImageAlt: 'Holzriese-Skulptur am Sonnenstein mit weitem Panoramablick über das Eichsfeld im Winter'
 distanceKm: 14
@@ -9,15 +9,15 @@ drivingMinutes: 16
 category: natur
 shortDescription: 'Spektakuläre Aussichtsplattform mit Panoramablick'
 intro: >-
-  Der Skywalk am Sonnenstein bei Holungen bietet ein unvergessliches
+  Der Skywalk am Sonnenstein bei Holungen ist ein besonderes
   Naturerlebnis. Die frei schwebende Aussichtsplattform ragt über
-  den Felsen hinaus und belohnt mutige Besucher mit einem atemberaubenden
+  den Felsen hinaus und belohnt mutige Besucher mit einem weiten
   Panorama über das Eichsfeld.
 content: >-
   Etwa 14 Kilometer von unserer Pension entfernt erwartet Sie der
-  Skywalk am Sonnenstein – eine der spektakulärsten Aussichtsplattformen
+  Skywalk am Sonnenstein, eine der spektakulärsten Aussichtsplattformen
   im Eichsfeld. Die Stahlkonstruktion ragt mehrere Meter frei über den
-  Felsrand hinaus und bietet einen einzigartigen Blick in die Tiefe
+  Felsrand hinaus und bietet einen freien Blick in die Tiefe
   und über die weite Landschaft.
 
 

--- a/content/attractions/vitalpark-heiligenstadt.yml
+++ b/content/attractions/vitalpark-heiligenstadt.yml
@@ -41,11 +41,11 @@ content: >-
   Ideal lässt sich der Stadtbummel mit einem Besuch im
   Vitalpark verbinden: Thermalbäder, acht Saunen von der
   Erdsauna bis zur finnischen Sauna, ein Rasul, Saunagarten
-  und Turmbar – perfekt zum Entspannen nach einem aktiven Tag.
+  und Turmbar, perfekt zum Entspannen nach einem aktiven Tag.
 hostTip: >-
   Unser Tipp: Vormittags durch die Altstadt bummeln und
   nachmittags im Vitalpark entspannen. Falls Sie über Ostern
-  bei uns sind, erleben Sie die Palmsonntagsprozession –
+  bei uns sind, erleben Sie die Palmsonntagsprozession,
   ein UNESCO-Kulturerbe und ganz besonderes Ereignis.
 bestTimeToVisit: 'Ganzjährig'
 website: 'https://www.heilbad-heiligenstadt.de'

--- a/content/attractions/wartburg.yml
+++ b/content/attractions/wartburg.yml
@@ -17,7 +17,7 @@ content: >-
   Etwa 55 Kilometer von unserer Pension entfernt thront die
   Wartburg majestätisch auf einem Felsen über Eisenach. Die
   über 900 Jahre alte Burg ist eng mit der deutschen Geschichte
-  verknüpft – von den Minnesängern um 1200 über die Heilige
+  verknüpft: von den Minnesängern um 1200 über die Heilige
   Elisabeth bis hin zu Martin Luthers Bibelübersetzung 1521/22.
 
 

--- a/content/events/config.yml
+++ b/content/events/config.yml
@@ -48,9 +48,9 @@ basePackage:
       price: 4490
   includes:
     - >-
-      Exklusive Buchung der gesamten Pension fürs Wochenende – alle 6 Zimmer &
+      Exklusive Buchung der gesamten Pension fürs Wochenende: alle 6 Zimmer &
       Ferienwohnungen für bis zu 18 Übernachtungsgäste
-    - Persönliche Eventplanung, Organisation und Koordination – wir sind für Sie da
+    - 'Persönliche Eventplanung, Organisation und Koordination: Wir sind für Sie da'
     - Festzelt mit schließbaren Seitenwänden und Beleuchtung (Ihr Schlechtwetter-Plan), passend zur Gästezahl
     - Bestuhlung für alle Gäste
     - Professionelle Endreinigung nach der Feier
@@ -67,22 +67,22 @@ cateringTiers:
     imageAlt: Rustikales Buffet mit regionalen, saisonalen Gerichten
     description: >-
       Herzhaftes Buffet unseres Partner-Caterers mit regionalen, saisonalen
-      Gerichten – unkompliziert und reichhaltig. Ideal für entspannte Familienfeiern.
+      Gerichten, unkompliziert und reichhaltig. Ideal für entspannte Familienfeiern.
     pricePerPerson: 45
   - id: klassisch
     label: Klassisches Festbuffet
     image: /img/events/catering-klassisch.webp
     imageAlt: Reich gedecktes klassisches Festbuffet
     description: >-
-      Vielfältiges Buffet mit warmen und kalten Speisen, Salaten und Dessert –
-      der beliebte Klassiker unseres Partner-Caterers für Hochzeiten und große Feste.
+      Vielfältiges Buffet mit warmen und kalten Speisen, Salaten und Dessert.
+      Der beliebte Klassiker unseres Partner-Caterers für Hochzeiten und große Feste.
     pricePerPerson: 69
   - id: premium
     label: Premium-Menü am Platz
     image: /img/events/catering-premium.webp
     imageAlt: Serviertes Premium-Menü am festlich gedeckten Tisch
     description: >-
-      Mehrgängiges, serviertes Menü mit Service am Tisch – die festlichste und
+      Mehrgängiges, serviertes Menü mit Service am Tisch: die festlichste und
       eleganteste Variante unseres Partner-Caterers für besondere Anlässe.
     pricePerPerson: 105
 
@@ -124,11 +124,11 @@ ceremonyOptions:
     imageAlt: Freie Trauzeremonie im Garten
     description: >-
       Persönliche, freie Trauzeremonie unter freiem Himmel mit einem professionellen
-      Trauredner – individuell auf Ihre Geschichte abgestimmt.
+      Trauredner, individuell auf Ihre Geschichte abgestimmt.
     detail: >-
       Sie heiraten direkt bei uns im Garten: ein erfahrener freier Trauredner
-      gestaltet Ihre Zeremonie ganz persönlich. Wir richten den Traubereich her –
-      so wird Trauung und Feier zu einem stimmungsvollen Tag an einem Ort, ohne
+      gestaltet Ihre Zeremonie ganz persönlich. Wir richten den Traubereich her,
+      sodass Trauung und Feier zu einem stimmungsvollen Tag an einem Ort werden, ohne
       Fahrt dazwischen. Enthält Vorgespräch, persönliche Rede und Zeremonie.
     price: 1190
 
@@ -138,18 +138,18 @@ photographyOptions:
   - id: keine
     label: Kein Fotograf
     description: Sie bringen Ihren eigenen Fotografen mit oder benötigen keinen.
-    detail: Sie organisieren die Fotos selbst – diese Position bleibt bei 0 €.
+    detail: Sie organisieren die Fotos selbst. Diese Position bleibt bei 0 €.
     price: 0
   - id: fotograf
     label: Fotograf – Reportage
     image: /img/events/foto-fotograf.webp
     imageAlt: Hochzeitsfotograf hält einen Moment der Feier fest
     description: >-
-      Professionelle Foto-Reportage Ihres Tages – natürliche Momentaufnahmen und
+      Professionelle Foto-Reportage Ihres Tages: natürliche Momentaufnahmen und
       Gruppenbilder, als bearbeitete Bildergalerie zum Download.
     detail: >-
       Ein erfahrener Fotograf begleitet Ihre Feier und hält die schönsten Momente
-      fest – vom Empfang bis zum Abend. Sie erhalten die bearbeiteten Bilder digital.
+      fest, vom Empfang bis zum Abend. Sie erhalten die bearbeiteten Bilder digital.
       Ein Klassiker, den fast alle Hochzeitspaare wählen.
     price: 1490
   - id: foto_video
@@ -159,7 +159,7 @@ photographyOptions:
     description: >-
       Foto-Reportage plus filmischer Zusammenschnitt Ihres Tages als Erinnerungsvideo.
     detail: >-
-      Zusätzlich zur Fotoreportage entsteht ein professioneller Film Ihres Tages –
+      Zusätzlich zur Fotoreportage entsteht ein professioneller Film Ihres Tages:
       ein bewegendes Andenken, das Sie immer wieder ansehen können. Ideal für
       Hochzeiten und große Jubiläen.
     price: 2290
@@ -177,7 +177,7 @@ musicOptions:
     imageAlt: Professionelle Musikanlage mit Lautsprechern
     description: >-
       Professionelle Musikanlage inkl. Lieferung, Aufbau und Anschluss Ihres eigenen
-      Geräts – Sie spielen Ihre eigene Playlist. Strom aus dem Haus.
+      Geräts. Sie spielen Ihre eigene Playlist. Strom aus dem Haus.
     price: 290
   - id: dj
     label: DJ komplett
@@ -196,19 +196,19 @@ tableOptions:
     label: Biertischgarnituren (rustikal)
     image: /img/events/tische-biertisch.webp
     imageAlt: Rustikale Holz-Biertischgarnituren mit Bänken
-    description: Klassische Holz-Biertischgarnituren mit Bänken – im Basispreis enthalten.
+    description: Klassische Holz-Biertischgarnituren mit Bänken, im Basispreis enthalten.
     pricePerPerson: 0
   - id: bankett
     label: Eckige Bankett-Tische
     image: /img/events/tische-bankett.webp
     imageAlt: Lange eckige Bankett-Tafeln mit Einzelstühlen
-    description: Lange Tafeln mit Einzelstühlen – festlich und gesellig.
+    description: 'Lange Tafeln mit Einzelstühlen: festlich und gesellig.'
     pricePerPerson: 5
   - id: rund
     label: Runde Festtische
     image: /img/events/tische-rund.webp
     imageAlt: Elegante runde Festtische mit Bestuhlung
-    description: Elegante runde Tische für 8–10 Personen – die klassische Hochzeitsbestuhlung.
+    description: Elegante runde Tische für 8–10 Personen, die klassische Hochzeitsbestuhlung.
     pricePerPerson: 6
 
 chairCoverOptions:
@@ -226,7 +226,7 @@ chairCoverOptions:
 dishwareOptions:
   - id: caterer
     label: Geschirr über den Caterer
-    description: Teller, Gläser und Besteck stellt unser Partner-Caterer – im Catering enthalten.
+    description: Teller, Gläser und Besteck stellt unser Partner-Caterer, im Catering enthalten.
     pricePerPerson: 0
   - id: mietgeschirr
     label: Komplettes Mietgeschirr
@@ -242,7 +242,7 @@ flooringOptions:
     image: /img/events/boden-tanzflaeche.webp
     imageAlt: Ausgelegte Holz-Tanzfläche im Garten
     description: >-
-      Ausgelegte Holz-Tanzfläche – schützt den Rasen im Hauptbereich und schafft
+      Ausgelegte Holz-Tanzfläche: schützt den Rasen im Hauptbereich und schafft
       eine schöne Fläche zum Tanzen.
     pricePerPerson: 5
   - id: komplett
@@ -250,7 +250,7 @@ flooringOptions:
     image: /img/events/boden-komplett.webp
     imageAlt: Durchgehender Holzboden im Festzelt
     description: >-
-      Durchgehender Holzboden im gesamten Zelt – maximaler Schutz für Ihren Rasen
+      Durchgehender Holzboden im gesamten Zelt: maximaler Schutz für Ihren Rasen
       und ein edles Ambiente, auch bei Nässe.
     pricePerPerson: 12
   - id: keiner
@@ -269,7 +269,7 @@ decorationOptions:
     label: Schlichte Tischdekoration
     image: /img/events/deko-schlicht.webp
     imageAlt: Schlichte Tischdekoration mit Blumen und Kerzen
-    description: Dezenter Blumenschmuck und Kerzen auf den Tischen – schlicht und stimmungsvoll.
+    description: Dezenter Blumenschmuck und Kerzen auf den Tischen, schlicht und stimmungsvoll.
     pricePerPerson: 8
   - id: klassisch
     label: Klassische Festdekoration
@@ -283,7 +283,7 @@ decorationOptions:
     imageAlt: Aufwändige florale Premium-Dekoration
     description: >-
       Aufwändige florale Gestaltung mit hochwertigen Arrangements für Tische, Zelt
-      und Eingang – das festliche Rundum-Paket.
+      und Eingang: das festliche Rundum-Paket.
     pricePerPerson: 20
 
 # Torte & Sweet Table: keine / Hochzeitstorte / Torte + Sweet Table. Pro Person.
@@ -292,7 +292,7 @@ cakeOptions:
   - id: keine
     label: Keine Torte
     description: Sie bringen Ihre eigene Torte mit oder verzichten darauf.
-    detail: Kuchen/Torte organisieren Sie selbst – diese Position bleibt bei 0 €.
+    detail: Kuchen/Torte organisieren Sie selbst. Diese Position bleibt bei 0 €.
     pricePerPerson: 0
   - id: torte
     label: Festtorte
@@ -300,7 +300,7 @@ cakeOptions:
     imageAlt: Mehrstöckige Festtorte
     description: >-
       Mehrstöckige Festtorte vom Konditor, abgestimmt auf Anlass, Geschmack und
-      Gästezahl – der süße Höhepunkt Ihrer Feier.
+      Gästezahl: der süße Höhepunkt Ihrer Feier.
     detail: >-
       Der klassische Moment: das gemeinsame Anschneiden der Torte. Wir stimmen
       Größe, Geschmack und Optik mit unserem Konditor auf Ihren Anlass ab.
@@ -315,7 +315,7 @@ cakeOptions:
       Pralinen und mehr zum Naschen über den ganzen Tag.
     detail: >-
       Zusätzlich zur Torte eine dekorative Süßigkeiten-Ecke, an der sich Ihre Gäste
-      den ganzen Tag bedienen können – ein beliebter Hingucker, besonders für Kinder.
+      den ganzen Tag bedienen können, ein beliebter Hingucker, besonders für Kinder.
     pricePerPerson: 14
 
 # Fotobox: keine / Fotobox mit Requisiten. Fester Preis inkl. Aufbau & Betreuung.
@@ -331,7 +331,7 @@ photoboothOptions:
     image: /img/events/fotobox.webp
     imageAlt: Fotobox mit lustigen Requisiten
     description: >-
-      Fotobox mit lustigen Requisiten und Sofortausdruck – für viele Lacher und ein
+      Fotobox mit lustigen Requisiten und Sofortausdruck, für viele Lacher und ein
       Gästebuch voller Erinnerungen.
     detail: >-
       Der Unterhaltungs-Hit für Ihre Gäste: Fotos mit Verkleidungen und Sofortdruck,
@@ -365,7 +365,7 @@ stylingOptions:
     description: >-
       Styling für die Braut plus eine weitere Person (Partnerin, Mutter, Trauzeugin).
     detail: >-
-      Wie das Braut-Styling, zusätzlich für eine zweite Person – ideal, wenn Sie sich
+      Wie das Braut-Styling, zusätzlich für eine zweite Person: ideal, wenn Sie sich
       gemeinsam vorbereiten möchten.
     price: 650
 
@@ -373,7 +373,7 @@ stylingOptions:
 occasions:
   - id: hochzeit
     label: Hochzeit
-    description: Heiraten im Grünen – intim, persönlich und unvergesslich.
+    description: Heiraten im Grünen, intim und persönlich.
     icon: ph:heart-duotone
   - id: jugendweihe
     label: Jugendweihe / Konfirmation
@@ -393,7 +393,7 @@ occasions:
     icon: ph:confetti-duotone
   - id: firmenfeier
     label: Firmenfeier
-    description: Sommerfest, Teamevent oder Firmenjubiläum im Grünen – fernab vom Büroalltag.
+    description: Sommerfest, Teamevent oder Firmenjubiläum im Grünen, fernab vom Büroalltag.
     icon: ph:briefcase-duotone
 
 disclaimer: >-

--- a/content/news-en/baerenpark-festival-2026.yml
+++ b/content/news-en/baerenpark-festival-2026.yml
@@ -11,7 +11,7 @@ category: veranstaltung
 excerpt: >-
   On June 27 and 28, 2026, Bear Park Worbis becomes a festival
   venue: live music, a children's programme, and hands-on animal
-  welfare – just 6 km from our guesthouse.
+  welfare, just 6 km from our guesthouse.
 intro: >-
   The Alternative Bear Park Worbis, only 6 kilometres from our
   guesthouse, invites visitors to the Wir.Sind.Tier. Festival on

--- a/content/news-en/landesgartenschau-2026.yml
+++ b/content/news-en/landesgartenschau-2026.yml
@@ -3,17 +3,17 @@ slug: landesgartenschau-2026
 seoTitle: 'State Garden Show 2026 Accommodation | Pension Volgenandt'
 seoDescription: >-
   Stay near the 2026 State Garden Show in Leinefelde-Worbis. Pension just
-  5 min away – apartments & rooms from 50 €/night.
+  5 min away, with apartments & rooms from 50 €/night.
 heroImage: '/img/content/landesgartenschau-2026.webp'
 heroImageAlt: 'State Garden Show 2026 in Leinefelde-Worbis'
 publishedDate: '2026-02-15'
 category: veranstaltung
 excerpt: >-
   From April 23 to October 11, 2026, Leinefelde-Worbis transforms into
-  a blooming event venue – right on our doorstep.
+  a blooming event venue right on our doorstep.
 intro: >-
   The Thuringian State Garden Show 2026 takes place right in our
-  neighbouring town of Leinefelde-Worbis – just a few minutes' drive
+  neighbouring town of Leinefelde-Worbis, just a few minutes' drive
   from our guesthouse. For half a year, the town transforms into a
   blooming event venue with over 1,500 events.
 content: >-
@@ -23,7 +23,7 @@ content: >-
   displays, the redesigned Augarten, the Lunapark with Tuffers Garten,
   and the newly created Garden City.
 
-  Over 1,500 events are planned – from concerts and workshops to yoga
+  Over 1,500 events are planned, from concerts and workshops to yoga
   and educational programmes. Everything is included in the admission
   price. For families there is a futuristic playground, a new skate park,
   and a basketball court.
@@ -31,10 +31,10 @@ content: >-
   A special highlight is the digitalisation of the medieval village of
   Kirrode: an EU-funded multimedia experience brings history to life.
   In the "Blumen-Block", a former GDR apartment block is repurposed as
-  an exhibition stage – a creative dialogue between past and future.
+  an exhibition stage: a creative dialogue between past and future.
 
   Over 300,000 visitors are expected. Our guesthouse is the ideal base
-  – and in a way an unofficial part of the garden show: in our own garden,
+  and in a way an unofficial part of the garden show: in our own garden,
   various fruit trees, berries, and vegetables grow, the wildflower
   meadow from ImmerBunt provides a home for bees and butterflies, and
   the deadwood corner offers shelter for hedgehogs and wild bees. What
@@ -43,7 +43,7 @@ content: >-
 
   In the morning you enjoy breakfast with us featuring homemade jam and
   fruit from our own garden, during the day you experience the Garden
-  Show in Leinefelde-Worbis – just a few minutes' drive away. In the
+  Show in Leinefelde-Worbis, just a few minutes' drive away. In the
   evening you return to the tranquillity of our green garden.
 externalLinks:
   - label: 'Official State Garden Show website'

--- a/content/news-en/neuer-radweg-unstrut-leine.yml
+++ b/content/news-en/neuer-radweg-unstrut-leine.yml
@@ -10,7 +10,7 @@ publishedDate: '2025-05-01'
 category: region
 excerpt: >-
   Since 2025, a new 9.4 km cycle path connects the Unstrut Cycle Route
-  with the Leine-Heide Cycle Route – closing a gap in the cycle network.
+  with the Leine-Heide Cycle Route, closing a gap in the cycle network.
 intro: >-
   Good news for cyclists: since spring 2025, there is a new connecting
   cycle path between the Unstrut Cycle Route and the Leine-Heide Cycle
@@ -29,7 +29,7 @@ content: >-
 
   Combined with the existing Leine Cycle Route, which passes directly
   by Breitenbach, there are now extensive circular tours through the
-  entire Eichsfeld. Our guesthouse is an ideal starting point – and
+  entire Eichsfeld. Our guesthouse is an ideal starting point, and
   after a long ride you can look forward to a good breakfast the
   next morning.
 externalLinks:

--- a/content/news-en/open-air-burg-scharfenstein-2026.yml
+++ b/content/news-en/open-air-burg-scharfenstein-2026.yml
@@ -10,16 +10,16 @@ publishedDate: '2026-02-10'
 category: veranstaltung
 excerpt: >-
   On August 7 and 8, 2026, NENA, The Sweet, Slade, and T. Rex rock
-  Scharfenstein Castle – a concert highlight in the Garden Show year.
+  Scharfenstein Castle as a concert highlight in the Garden Show year.
 intro: >-
   In the Garden Show year 2026, Scharfenstein Castle becomes an open-air
   stage: on two evenings in August, international music stars perform
-  against the unique backdrop of the medieval castle.
+  against the atmospheric backdrop of the medieval castle.
 content: >-
   On Friday, August 7, 2026, The Sweet, Slade, and T. Rex open the
   open-air weekend with the "Traumhits Summer Open Air". From 6:30 pm,
   the greatest hits of the 70s and 80s ring out in the atmospheric
-  castle setting – with space for up to 15,000 guests.
+  castle setting, which holds up to 15,000 guests.
 
   On Saturday, August 8, 2026, NENA takes the stage with her ten-piece
   band. In a concert lasting over two hours, she performs hits spanning

--- a/content/news-en/wespennest-terrasse.yml
+++ b/content/news-en/wespennest-terrasse.yml
@@ -1,0 +1,75 @@
+title: 'Why We Simply Let the Wasp Nest on Our Terrace Be'
+slug: wespennest-terrasse
+seoTitle: 'Why We Let Our Terrace Wasp Nest Be'
+seoDescription: >-
+  A wasp colony has settled on our terrace. Wasps are important
+  beneficial insects and their nests can often simply stay.
+heroImage: '/img/garten/wespennest-terrasse.webp'
+heroImageAlt: 'Wasp nest under the roof of our terrace at Pension Volgenandt'
+publishedDate: '2026-08-09'
+category: pension
+excerpt: >-
+  A wasp colony has built its nest on our terrace. We explain why
+  wasps are important beneficial insects and why their nests usually
+  do not need to be removed at all.
+intro: >-
+  For several weeks now we have been watching a lively bustle under
+  our terrace roof. A colony of wasps has built its nest there. That
+  might sound alarming at first, but to us it is mostly interesting.
+  Wasps have a bad reputation they really do not deserve.
+content: >-
+  Paper wasps build their nests from chewed wood mixed with saliva
+  into a paper like material. Layer by layer, this becomes an
+  intricate honeycomb shaped structure. Over the course of this
+  summer, a large nest has grown on our terrace, with many wasps
+  flying in and out every day. Look closely and you will see a
+  social insect colony with a clear division of labour, from the
+  queen down to the worker wasps gathering food for the brood.
+
+  What many people do not know is that wasps are important
+  beneficial insects in the garden. A single colony consumes several
+  kilograms of insects over a summer, mainly aphids, flies and
+  caterpillars that would otherwise damage plants and crops. In
+  doing so, wasps provide natural pest control that would otherwise
+  require chemical treatment. Only in late summer, once brood care
+  ends, do the wasps need more nectar and sugar. That is when they
+  start showing up at the coffee table. The nest itself is only used
+  for a single season. In autumn, the whole colony dies except for
+  the new queen, who overwinters alone and founds a new nest in
+  spring.
+
+  That is exactly why it is worth thinking twice before removing a
+  wasp nest. In Germany, wasps and their nests are even under
+  special legal protection, so destroying one without good reason is
+  not permitted. More important than any rule, though, is what we
+  have experienced ourselves. As long as you keep a respectful
+  distance, avoid sudden movements and do not block the wasps'
+  flight path, living alongside them is surprisingly relaxed. Only
+  in heavily used spots, such as right above a child's swing, or if
+  someone has a known insect venom allergy, does professional
+  relocation make sense, ideally with a trained wasp advisor rather
+  than on your own.
+
+  Still, nobody has to simply put up with every wasp at the coffee
+  table. According to NABU, it helps to place a plate of overripe
+  fruit, for example grapes or half a peach, a few metres away from
+  your own table in the sun. The wasps usually find food there
+  faster than on your cake and leave the coffee table alone. Pure
+  honey or jam do not work as well for this, they tend to make the
+  wasps more aggressive. It also helps to stay calm. Sudden
+  movements and blowing at the wasps only make them nervous, since
+  carbon dioxide in human breath acts as an alarm signal in the
+  nest. We would advise against wasp traps with sweet liquid or
+  beer. The wasps die a slow death in them, and so do many other
+  insects.
+
+  Our terrace wasp nest is staying right where it is. If you are
+  staying with us, we are happy to show it to you. Seen from a safe
+  distance, it is a lovely piece of nature, right in the garden of
+  Pension Volgenandt.
+externalLinks:
+  - label: 'NABU: Tips on Wasps and Hornets (German)'
+    url: 'https://www.nabu.de/tiere-und-pflanzen/insekten-und-spinnen/hautfluegler/wespen-und-hornissen/02624.html'
+  - label: 'More about our approach to sustainability'
+    url: 'https://www.pension-volgenandt.de/en/sustainability/'
+sortOrder: 0

--- a/content/news/baerenpark-festival-2026.yml
+++ b/content/news/baerenpark-festival-2026.yml
@@ -11,7 +11,7 @@ category: veranstaltung
 excerpt: >-
   Am 27. und 28. Juni 2026 wird der Bärenpark Worbis zum
   Festival-Gelände: Live-Musik, Kinderprogramm und Tierschutz
-  zum Anfassen – nur 6 km von unserer Pension.
+  zum Anfassen, nur 6 km von unserer Pension.
 intro: >-
   Der Alternative Bärenpark Worbis, nur 6 Kilometer von unserer Pension
   entfernt, lädt am 27. und 28. Juni 2026 zum Wir.Sind.Tier. Festival

--- a/content/news/landesgartenschau-2026.yml
+++ b/content/news/landesgartenschau-2026.yml
@@ -3,17 +3,17 @@ slug: landesgartenschau-2026
 seoTitle: 'Landesgartenschau 2026 Unterkunft | Pension Volgenandt'
 seoDescription: >-
   Übernachten Sie zur Landesgartenschau 2026 in Leinefelde-Worbis. Pension
-  nur 5 Min entfernt – Zimmer & Ferienwohnungen ab 50 €/Nacht.
+  nur 5 Min entfernt. Zimmer & Ferienwohnungen ab 50 €/Nacht.
 heroImage: '/img/content/landesgartenschau-2026.webp'
 heroImageAlt: 'Landesgartenschau 2026 in Leinefelde-Worbis'
 publishedDate: '2026-02-15'
 category: veranstaltung
 excerpt: >-
-  Vom 23. April bis 11. Oktober 2026 verwandelt sich Leinefelde-Worbis in
-  einen blühenden Veranstaltungsort – direkt vor unserer Haustür.
+  Vom 23. April bis 11. Oktober 2026 verwandelt sich Leinefelde-Worbis
+  direkt vor unserer Haustür in einen blühenden Veranstaltungsort.
 intro: >-
   Die Thüringer Landesgartenschau 2026 findet direkt in unserer
-  Nachbarstadt Leinefelde-Worbis statt – nur wenige Autominuten von
+  Nachbarstadt Leinefelde-Worbis statt, nur wenige Autominuten von
   unserer Pension entfernt. Ein halbes Jahr lang verwandelt sich die
   Stadt in einen blühenden Veranstaltungsort mit über 1.500 Events.
 content: >-
@@ -23,7 +23,7 @@ content: >-
   Gartenanlagen, den neu gestalteten Augarten, den Lunapark mit Tüffers
   Garten und die neu entstandene Gartenstadt.
 
-  Über 1.500 Veranstaltungen sind geplant – von Konzerten und Workshops
+  Über 1.500 Veranstaltungen sind geplant, von Konzerten und Workshops
   über Yoga bis hin zu Bildungsprogrammen. Alles ist im Eintrittspreis
   enthalten. Für Familien gibt es einen futuristischen Spielplatz, einen
   neuen Skatepark und einen Basketballplatz.
@@ -31,11 +31,11 @@ content: >-
   Ein besonderes Highlight ist die Digitalisierung des mittelalterlichen
   Dorfes Kirrode: Ein EU-gefördertes Multimedia-Erlebnis macht Geschichte
   lebendig. Im „Blumen-Block" wird ein ehemaliger DDR-Wohnblock zur
-  Ausstellungsbühne umfunktioniert – ein kreativer Dialog zwischen
+  Ausstellungsbühne umfunktioniert: ein kreativer Dialog zwischen
   Vergangenheit und Zukunft.
 
   Es werden über 300.000 Besucher erwartet. Unsere Pension ist der ideale
-  Ausgangspunkt – und gewissermaßen ein inoffizieller Teil der
+  Ausgangspunkt und gewissermaßen ein inoffizieller Teil der
   Gartenschau: In unserem eigenen Garten wachsen verschiedene Obstarten,
   Beeren und Gemüse, die Blühwiese von ImmerBunt bietet Bienen und
   Schmetterlingen ein Zuhause, und in der Totholzecke finden Igel und
@@ -44,7 +44,7 @@ content: >-
 
   Morgens frühstücken Sie bei uns mit hausgemachter Marmelade und
   Obst aus dem eigenen Garten, tagsüber genießen Sie die Gartenschau
-  in Leinefelde-Worbis – nur wenige Autominuten entfernt. Abends
+  in Leinefelde-Worbis, nur wenige Autominuten entfernt. Abends
   kommen Sie zurück in die Ruhe unseres grünen Gartens.
 externalLinks:
   - label: 'Offizielle Website der Landesgartenschau'

--- a/content/news/neuer-radweg-unstrut-leine.yml
+++ b/content/news/neuer-radweg-unstrut-leine.yml
@@ -10,7 +10,7 @@ publishedDate: '2025-05-01'
 category: region
 excerpt: >-
   Seit 2025 verbindet ein neuer 9,4 km langer Radweg den Unstrut-Radweg
-  mit dem Leine-Heide-Radweg – eine Lücke im Radnetz ist geschlossen.
+  mit dem Leine-Heide-Radweg. Eine Lücke im Radnetz ist geschlossen.
 intro: >-
   Gute Nachrichten für Radfahrer: Seit Frühjahr 2025 gibt es einen
   neuen Verbindungsradweg zwischen dem Unstrut-Radweg und dem
@@ -23,14 +23,14 @@ content: >-
   sanfte Hügellandschaft des Eichsfelds.
 
   Thüringens Infrastrukturminister betonte bei der Eröffnung, dass
-  der Radweg nicht nur den Radtourismus stärkt, sondern auch den
-  Alltagsradverkehr in der Region sicherer macht. Für unsere Gäste
+  der Radweg den Radtourismus stärkt und zugleich den Alltagsradverkehr
+  in der Region sicherer macht. Für unsere Gäste
   bedeutet das: noch mehr Möglichkeiten für Tagestouren mit dem Rad.
 
   In Kombination mit dem bestehenden Leine-Radweg, der direkt an
   Breitenbach vorbeiführt, ergeben sich jetzt ausgedehnte
   Rundtouren durch das gesamte Eichsfeld. Unsere Pension ist ein
-  idealer Startpunkt – und nach einer langen Tour freuen Sie sich
+  idealer Startpunkt, und nach einer langen Tour freuen Sie sich
   auf ein gutes Frühstück am nächsten Morgen.
 externalLinks:
   - label: 'Radfahren im Eichsfeld'

--- a/content/news/open-air-burg-scharfenstein-2026.yml
+++ b/content/news/open-air-burg-scharfenstein-2026.yml
@@ -10,16 +10,16 @@ publishedDate: '2026-02-10'
 category: veranstaltung
 excerpt: >-
   Am 7. und 8. August 2026 rocken NENA, The Sweet, Slade und T. Rex
-  die Burg Scharfenstein – ein Konzert-Highlight im Gartenschau-Jahr.
+  die Burg Scharfenstein als Konzert-Highlight im Gartenschau-Jahr.
 intro: >-
   Im Gartenschau-Jahr 2026 wird Burg Scharfenstein zur Open-Air-Bühne:
   An zwei Abenden im August treten internationale Musikgrößen in der
-  einzigartigen Kulisse der mittelalterlichen Burg auf.
+  stimmungsvollen Kulisse der mittelalterlichen Burg auf.
 content: >-
   Am Freitag, dem 7. August 2026, eröffnen The Sweet, Slade und T. Rex
   das Open-Air-Wochenende mit dem „Traumhits Summer Open Air". Ab 18:30
   Uhr erklingen die größten Hits der 70er und 80er Jahre in der
-  stimmungsvollen Burgkulisse – Platz für bis zu 15.000 Gäste.
+  stimmungsvollen Burgkulisse, die Platz für bis zu 15.000 Gäste bietet.
 
   Am Samstag, dem 8. August 2026, betritt NENA mit ihrer zehnköpfigen
   Band die Bühne. In einem über zweistündigen Konzert spielt sie Hits

--- a/content/news/wespennest-terrasse.yml
+++ b/content/news/wespennest-terrasse.yml
@@ -1,0 +1,78 @@
+title: 'Warum wir das Wespennest auf unserer Terrasse einfach lassen'
+slug: wespennest-terrasse
+seoTitle: 'Warum wir unser Wespennest auf der Terrasse dulden'
+seoDescription: >-
+  Ein Wespenvolk hat sich auf unserer Terrasse eingenistet. Wespen
+  sind wichtige Nützlinge und ihre Nester können oft einfach bleiben.
+heroImage: '/img/garten/wespennest-terrasse.webp'
+heroImageAlt: 'Wespennest an der Terrassenüberdachung der Pension Volgenandt'
+publishedDate: '2026-08-09'
+category: pension
+excerpt: >-
+  Auf unserer Terrasse hat ein Wespenvolk sein Nest gebaut. Wir
+  erklären, warum Wespen wichtige Nützlinge sind und ihre Nester
+  meist gar nicht entfernt werden müssen.
+intro: >-
+  Seit einigen Wochen beobachten wir ein munteres Treiben unter
+  unserem Terrassendach. Ein Wespenvolk hat dort sein Nest gebaut.
+  Das klingt zunächst nach Grund zur Sorge, ist für uns aber vor
+  allem interessant. Wespen haben einen schlechten Ruf, den sie
+  eigentlich nicht verdienen.
+content: >-
+  Papierwespen bauen ihre Nester aus zerkautem Holz, das sie mit
+  Speichel zu einer papierartigen Masse verarbeiten. Schicht für
+  Schicht entsteht so ein wabenförmiges Gebilde. Bei uns auf der
+  Terrasse ist im Laufe des Sommers ein großes Nest entstanden, an
+  dem täglich viele Wespen ein und aus fliegen. Wer genau hinschaut,
+  erkennt ein soziales Insektenvolk mit klarer Aufgabenteilung, von
+  der Königin bis zu den Arbeiterinnen, die Futter für die Brut
+  sammeln.
+
+  Was viele nicht wissen: Wespen sind wichtige Nützlinge im Garten.
+  Ein einziges Volk vertilgt im Laufe eines Sommers mehrere Kilogramm
+  Insekten, vor allem Blattläuse, Fliegen und Raupen, die sonst
+  Pflanzen und Ernte schädigen würden. Damit übernehmen Wespen eine
+  natürliche Schädlingsbekämpfung, für die man sonst zur Chemiekeule
+  greifen müsste. Erst im Spätsommer, wenn die Brutpflege endet,
+  brauchen die Tiere mehr Nektar und Zucker. Dann werden sie auch am
+  Kaffeetisch lästig. Das Nest selbst wird zudem nur für eine Saison
+  genutzt. Im Herbst stirbt das gesamte Volk bis auf die neue
+  Königin, die allein überwintert und im Frühjahr ein neues Nest
+  gründet.
+
+  Genau deshalb lohnt es sich, ein Wespennest nicht vorschnell zu
+  entfernen. Wespen und ihre Nester stehen in Deutschland sogar unter
+  besonderem Schutz. Ein mutwilliges Zerstören ohne vernünftigen
+  Grund ist nicht erlaubt. Wichtiger als jede Vorschrift ist aber die
+  Erfahrung, die wir selbst gemacht haben. Solange man dem Nest nicht
+  zu nahekommt, keine hektischen Bewegungen macht und den Ein- und
+  Ausflug der Tiere nicht blockiert, lebt es sich mit Wespen
+  erstaunlich entspannt zusammen. Nur an stark frequentierten
+  Stellen, etwa direkt über einer Kinderschaukel, oder bei bekannten
+  Insektengiftallergien kann eine fachkundige Umsiedlung sinnvoll
+  sein. Am besten mit einem Wespenberater und nicht in Eigenregie.
+
+  Trotzdem muss niemand jede Wespe am Kaffeetisch einfach hinnehmen.
+  Nach Empfehlung des NABU hilft ein Teller mit überreifem Obst, zum
+  Beispiel Weintrauben oder eine halbe Pfirsichhälfte, der einige
+  Meter entfernt vom eigenen Tisch in der Sonne steht. Die Wespen
+  finden dort meist schneller Nahrung als bei uns am Kuchen und
+  lassen den Kaffeetisch dann in Ruhe. Reiner Honig oder pure
+  Marmelade eignen sich dafür übrigens schlecht, das macht die Tiere
+  eher aggressiv. Wichtig ist außerdem, ruhig zu bleiben. Hektische
+  Bewegungen und Pusten machen die Wespen erst nervös, denn
+  Kohlendioxid in der Atemluft gilt im Nest als Alarmsignal. Von
+  Wespenfallen mit süßer Flüssigkeit oder Bier raten wir ab. Die
+  Tiere sterben darin einen langsamen Tod, und mit ihnen viele andere
+  Insekten.
+
+  Unser Wespennest auf der Terrasse bleibt also, wo es ist. Wenn Sie
+  bei uns zu Gast sind, zeigen wir es Ihnen gern. Aus sicherem
+  Abstand ist es ein schönes Stück Natur, mitten im Garten der
+  Pension Volgenandt.
+externalLinks:
+  - label: 'NABU: Tipps zum Umgang mit Wespen und Hornissen'
+    url: 'https://www.nabu.de/tiere-und-pflanzen/insekten-und-spinnen/hautfluegler/wespen-und-hornissen/02624.html'
+  - label: 'Mehr zu unserer Nachhaltigkeit'
+    url: 'https://www.pension-volgenandt.de/nachhaltigkeit/'
+sortOrder: 0

--- a/content/rooms-en/balkonzimmer.yml
+++ b/content/rooms-en/balkonzimmer.yml
@@ -17,7 +17,7 @@ description: >-
   taking in the view of the courtyard. Wi-Fi and TV
   provide evening entertainment. The fully equipped
   shared kitchen and the terrace are available for all
-  guests – we kindly ask for consideration of others.
+  guests. We kindly ask for consideration of others.
 
 beds24PropertyId: 261258
 beds24RoomId: 548066
@@ -77,12 +77,12 @@ extras:
     price: 15
     unit: 'per person / night'
   - name: 'Picnic basket'
-    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside – we pack everything for you. Find inspiration on our trips & activities page.'
+    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside. We pack everything for you. Find inspiration on our trips & activities page.'
     price: 19
     pricePrefix: 'from '
     unit: 'per person'
   - name: 'Dog'
-    description: 'Your four-legged friend is welcome – our large garden offers plenty of space to run and explore.'
+    description: 'Your four-legged friend is welcome. Our large garden offers plenty of space to run and explore.'
     price: 5
     unit: 'per night'
   - name: 'BBQ set'

--- a/content/rooms-en/einzelzimmer.yml
+++ b/content/rooms-en/einzelzimmer.yml
@@ -16,7 +16,7 @@ description: >-
   Despite its compact size, the room offers everything
   you need for a pleasant stay. Our fully equipped
   shared kitchen and the terrace are available for all
-  guests – we kindly ask for consideration of others.
+  guests. We kindly ask for consideration of others.
 
 weekendOnly: true
 
@@ -68,7 +68,7 @@ extras:
     price: 15
     unit: 'per person / night'
   - name: 'Picnic basket'
-    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside – we pack everything for you. Find inspiration on our trips & activities page.'
+    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside. We pack everything for you. Find inspiration on our trips & activities page.'
     price: 19
     pricePrefix: 'from '
     unit: 'per person'

--- a/content/rooms-en/emils-kuhwiese.yml
+++ b/content/rooms-en/emils-kuhwiese.yml
@@ -6,7 +6,7 @@ type: ferienwohnung
 category: 'Ferienwohnung'
 shortDescription: >-
   Cosy holiday apartment with garden views. Own kitchen,
-  terrace and an additional sofa bed – ideal for
+  terrace and an additional sofa bed, ideal for
   2 guests or small families.
 description: >-
   The holiday apartment Emil's Kuhwiese offers
@@ -77,12 +77,12 @@ extras:
     price: 10
     unit: 'per person / night'
   - name: 'Picnic basket'
-    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside – we pack everything for you. Find inspiration on our trips & activities page.'
+    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside. We pack everything for you. Find inspiration on our trips & activities page.'
     price: 19
     pricePrefix: 'from '
     unit: 'per person'
   - name: 'Dog'
-    description: 'Your four-legged friend is welcome – our large garden offers plenty of space to run and explore.'
+    description: 'Your four-legged friend is welcome. Our large garden offers plenty of space to run and explore.'
     price: 5
     unit: 'per night'
   - name: 'BBQ set'

--- a/content/rooms-en/rosengarten.yml
+++ b/content/rooms-en/rosengarten.yml
@@ -16,7 +16,7 @@ description: >-
   furnishings await you. Wi-Fi and TV are of course
   included. Let the scent of roses lull you to sleep.
   Our fully equipped shared kitchen and the terrace are
-  available for all guests – we kindly ask for
+  available for all guests. We kindly ask for
   consideration of others.
 
 beds24PropertyId: 261258
@@ -74,7 +74,7 @@ extras:
     price: 10
     unit: 'per person / night'
   - name: 'Picnic basket'
-    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside – we pack everything for you. Find inspiration on our trips & activities page.'
+    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside. We pack everything for you. Find inspiration on our trips & activities page.'
     price: 19
     pricePrefix: 'from '
     unit: 'per person'

--- a/content/rooms-en/schoene-aussicht.yml
+++ b/content/rooms-en/schoene-aussicht.yml
@@ -7,7 +7,7 @@ category: 'Ferienwohnung'
 shortDescription: >-
   Spacious holiday apartment with stunning views across
   the Eichsfeld. Two bedrooms with en-suite bathrooms,
-  large living area with kitchen – ideal for up to
+  large living area with kitchen, ideal for up to
   6 guests.
 description: >-
   The holiday apartment Schöne Aussicht impresses with
@@ -88,7 +88,7 @@ extras:
     price: 10
     unit: 'per person / night'
   - name: 'Picnic basket'
-    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside – we pack everything for you. Find inspiration on our trips & activities page.'
+    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside. We pack everything for you. Find inspiration on our trips & activities page.'
     price: 19
     pricePrefix: 'from '
     unit: 'per person'

--- a/content/rooms-en/wohlfuehl-appartement.yml
+++ b/content/rooms-en/wohlfuehl-appartement.yml
@@ -16,7 +16,7 @@ description: >-
   suitable for e.g. children. Wi-Fi, TV and an en-suite
   bathroom with shower are included as standard. The
   fully equipped shared kitchen and the terrace are
-  available for all guests – we kindly ask for
+  available for all guests. We kindly ask for
   consideration of others.
 
 beds24PropertyId: 261258
@@ -79,7 +79,7 @@ extras:
     price: 10
     unit: 'per person / night'
   - name: 'Picnic basket'
-    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside – we pack everything for you. Find inspiration on our trips & activities page.'
+    description: 'Regional & homemade, with crockery and blanket. Relax in the pension garden, take it on a day trip, or discover your own favourite spot in the Eichsfeld countryside. We pack everything for you. Find inspiration on our trips & activities page.'
     price: 19
     pricePrefix: 'from '
     unit: 'per person'

--- a/content/rooms/balkonzimmer.yml
+++ b/content/rooms/balkonzimmer.yml
@@ -18,7 +18,8 @@ description: >-
   Innenhof schweifen lassen. WLAN und Fernseher sorgen
   für Unterhaltung am Abend. Die voll ausgestattete
   Gemeinschaftsküche und die Terrasse dürfen gerne genutzt
-  werden – wir bitten um Rücksichtnahme auf andere Gäste.
+  werden. Wir bitten dabei um Rücksichtnahme auf
+  andere Gäste.
 
 beds24PropertyId: 261258
 beds24RoomId: 548066
@@ -79,12 +80,12 @@ extras:
     price: 15
     unit: 'pro Person / Nacht'
   - name: 'Picknick-Korb'
-    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen – wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
+    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen. Wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
     price: 19
     pricePrefix: 'ab '
     unit: 'pro Person'
   - name: 'Hund'
-    description: 'Ihr Vierbeiner ist bei uns herzlich willkommen – unser großer Garten bietet viel Platz zum Toben und Schnüffeln.'
+    description: 'Ihr Vierbeiner ist bei uns herzlich willkommen. Unser großer Garten bietet viel Platz zum Toben und Schnüffeln.'
     price: 5
     unit: 'pro Nacht'
   - name: 'Grill-Set'

--- a/content/rooms/einzelzimmer.yml
+++ b/content/rooms/einzelzimmer.yml
@@ -17,8 +17,8 @@ description: >-
   Trotz seiner kompakten Größe bietet das Zimmer alles,
   was Sie für einen angenehmen Aufenthalt brauchen.
   Unsere voll ausgestattete Gemeinschaftsküche und die
-  Terrasse dürfen gerne genutzt werden – wir bitten um
-  Rücksichtnahme auf andere Gäste.
+  Terrasse dürfen gerne genutzt werden. Wir bitten
+  dabei um Rücksichtnahme auf andere Gäste.
 
 weekendOnly: true
 
@@ -71,7 +71,7 @@ extras:
     price: 15
     unit: 'pro Person / Nacht'
   - name: 'Picknick-Korb'
-    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen – wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
+    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen. Wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
     price: 19
     pricePrefix: 'ab '
     unit: 'pro Person'

--- a/content/rooms/emils-kuhwiese.yml
+++ b/content/rooms/emils-kuhwiese.yml
@@ -7,7 +7,7 @@ category: 'Ferienwohnung'
 shortDescription: >-
   Gemütliche Ferienwohnung mit Blick in den Garten.
   Eigene Küche, Terrasse und ein zusätzliches
-  Schlafsofa – ideal für 2 Personen oder kleine Familien.
+  Schlafsofa, ideal für 2 Personen oder kleine Familien.
 description: >-
   Die Ferienwohnung Emil's Kuhwiese bietet Ihnen
   alles, was Sie für einen entspannten Aufenthalt brauchen.
@@ -77,12 +77,12 @@ extras:
     price: 10
     unit: 'pro Person / Nacht'
   - name: 'Picknick-Korb'
-    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen – wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
+    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen. Wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
     price: 19
     pricePrefix: 'ab '
     unit: 'pro Person'
   - name: 'Hund'
-    description: 'Ihr Vierbeiner ist bei uns herzlich willkommen – unser großer Garten bietet viel Platz zum Toben und Schnüffeln.'
+    description: 'Ihr Vierbeiner ist bei uns herzlich willkommen. Unser großer Garten bietet viel Platz zum Toben und Schnüffeln.'
     price: 5
     unit: 'pro Nacht'
   - name: 'Grill-Set'

--- a/content/rooms/rosengarten.yml
+++ b/content/rooms/rosengarten.yml
@@ -18,8 +18,8 @@ description: >-
   zur Verfügung. Lassen Sie sich vom Duft der Rosen in
   den Schlaf wiegen. Unsere voll ausgestattete
   Gemeinschaftsküche und die Terrasse dürfen gerne
-  genutzt werden – wir bitten um Rücksichtnahme auf
-  andere Gäste.
+  genutzt werden. Wir bitten dabei um Rücksichtnahme
+  auf andere Gäste.
 
 beds24PropertyId: 261258
 beds24RoomId: 549252
@@ -77,7 +77,7 @@ extras:
     price: 10
     unit: 'pro Person / Nacht'
   - name: 'Picknick-Korb'
-    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen – wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
+    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen. Wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
     price: 19
     pricePrefix: 'ab '
     unit: 'pro Person'

--- a/content/rooms/schoene-aussicht.yml
+++ b/content/rooms/schoene-aussicht.yml
@@ -7,7 +7,7 @@ category: 'Ferienwohnung'
 shortDescription: >-
   Großzügige Ferienwohnung mit schönem Ausblick über das
   Eichsfeld. Zwei Schlafzimmer mit eigenem Bad, großer
-  Wohnbereich mit Küche – ideal für bis zu 6 Gäste.
+  Wohnbereich mit Küche, ideal für bis zu 6 Gäste.
 description: >-
   Die Ferienwohnung Schöne Aussicht überzeugt mit ihrem
   weiten Blick über die Hügellandschaft des Eichsfelds.
@@ -87,7 +87,7 @@ extras:
     price: 10
     unit: 'pro Person / Nacht'
   - name: 'Picknick-Korb'
-    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen – wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
+    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen. Wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
     price: 19
     pricePrefix: 'ab '
     unit: 'pro Person'

--- a/content/rooms/wohlfuehl-appartement.yml
+++ b/content/rooms/wohlfuehl-appartement.yml
@@ -17,8 +17,8 @@ description: >-
   Kinder. WLAN, Fernseher und ein eigenes Badezimmer
   mit Dusche gehören selbstverständlich dazu. Die voll
   ausgestattete Gemeinschaftsküche und die Terrasse dürfen
-  gerne genutzt werden – wir bitten um Rücksichtnahme
-  auf andere Gäste.
+  gerne genutzt werden. Wir bitten dabei um
+  Rücksichtnahme auf andere Gäste.
 
 beds24PropertyId: 261258
 beds24RoomId: 549319
@@ -80,7 +80,7 @@ extras:
     price: 10
     unit: 'pro Person / Nacht'
   - name: 'Picknick-Korb'
-    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen – wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
+    description: 'Regional & hausgemacht, mit Geschirr und Decke. Im Garten der Pension entspannen, auf einen Ausflug mitnehmen oder einen Lieblingsplatz in der Eichsfelder Natur suchen. Wir packen alles ein. Ausflugstipps gibt es auf unserer Website.'
     price: 19
     pricePrefix: 'ab '
     unit: 'pro Person'


### PR DESCRIPTION
## Summary
- Rewrote ~200 em-dash "clause – appositive" constructions and stock marketing phrases (einzigartig, unvergesslich, Erleben Sie, nicht nur...sondern auch, etc.) into plain sentences across rooms, attractions (DE+EN), news, activities, picknick, FAQ, the Feiern event-config, i18n locale strings, page meta descriptions/alt text, and shared components
- Added new Aktuelles article "Wespennest auf der Terrasse" (DE+EN) about wasps as beneficial insects, with NABU-sourced tips and a link to the Nachhaltigkeit page
- Expanded Eiscafé San Remo copy with a personal recommendation and a "Google Bewertungen" review link instead of a hardcoded rating
- Added a "for tradespeople" section to the Monteurzimmer page (DE+EN)
- Generalized the news-article soft-CTA copy (was hardcoded to "Veranstaltung" for every article)
- Fixed a YAML syntax bug introduced by one colon-replacement in events/config.yml

## Test plan
- [x] `npx eslint .` — 0 errors
- [x] `npx prettier --check` — passes (pre-existing CRLF warnings unrelated to this diff)
- [x] `npx nuxi typecheck` — clean
- [x] All 17 Nuxt Content collections (64 files) parse without schema errors
- [x] Spot-checked live in dev server: Feiern configurator, Wartburg attraction page, Monteurzimmer page, Eiscafé San Remo page, Wespen article
- [ ] Add real terrace photo for the Wespen article (`public/img/garten/wespennest-terrasse.webp` is currently a placeholder path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)