### PR TITLE
feat(invoicing): save button, send preview, and review-page fixes

### DIFF
--- a/server/invoice-draft.php
+++ b/server/invoice-draft.php
@@ -113,7 +113,14 @@ function generateInvoiceDraftIfNeeded(int $bookingId, array $webhookItems = []):
 
     $existing = findDraftsForBooking($groupMasterId);
     $pending  = array_values(array_filter($existing, fn(array $d) => ($d['status'] ?? '') === 'pending'));
-    $approved = array_values(array_filter($existing, fn(array $d) => ($d['status'] ?? '') === 'approved'));
+    // 'ready' = number assigned + PDF generated on the review page, but not
+    // yet sent to the guest (see invoice-review.php's pending→ready→approved
+    // flow). Treated as "already invoiced" here, same as 'approved' — a
+    // webhook firing while a draft sits in 'ready' must diff against its
+    // charges (Nachtrag for genuinely new items) rather than spawning a
+    // second full-stay draft, since the number/PDF are already fixed and
+    // can't be silently refreshed like a true 'pending' draft can.
+    $approved = array_values(array_filter($existing, fn(array $d) => in_array($d['status'] ?? '', ['ready', 'approved'], true)));
 
     // A draft is already awaiting Simone's review — don't spawn a second one
     // just because Beds24 re-fired the webhook. Refresh it in place if the
@@ -322,7 +329,12 @@ function buildInvoiceDraft(array $booking, array $items, string $scenario, array
         ],
         'lineItems'     => $items,
         'totals'        => $totals,
-        'paymentNote'   => 'Zahlbar innerhalb von 7 Tagen nach Rechnungsstellung.',
+        // Firmenrechnungen (auto-detected below) get the 3-Werktage note right
+        // away instead of the generic 7-day text — otherwise the draft/preview
+        // shows the wrong term until Simone explicitly re-saves the form.
+        'paymentNote'   => !empty($extra['isFirmenrechnung'])
+            ? firmenPaymentNote()
+            : 'Zahlbar innerhalb von 7 Tagen nach Rechnungsstellung.',
         'note'          => $extra['note'] ?? '',
         'approvedAt'    => null,
         // Firmenrechnung (e.g. Fero Fensterbau, Barczewski) — auto-detected
@@ -401,9 +413,18 @@ function parseLineItems(array $booking, array $webhookItems = []): array {
     // invoices are indistinguishable ("Übernachtung" on all of them).
     $roomLabel = 'Übernachtung – ' . resolveRoomName($booking);
 
+    // Accommodation is billed per night — qty/unit price here (not just the
+    // summed gross) is what makeLineItem() shows in the "Anzahl"/"Einzelpreis"
+    // columns, previously always defaulted to qty=1/unit=total because neither
+    // was passed at all.
+    $in  = $booking['arrival']   ?? $booking['checkIn']  ?? $booking['arrivalDate']   ?? '';
+    $out = $booking['departure'] ?? $booking['checkOut'] ?? $booking['departureDate'] ?? '';
+    $nights = ($in && $out) ? (int)(new \DateTime($in))->diff(new \DateTime($out))->days : 0;
+    $nights = max(1, $nights);
+
     // No itemized invoice — fall back to room price only
     if (empty($invoiceItems)) {
-        return $basePrice > 0 ? [makeLineItem($roomLabel, $basePrice, 7)] : [];
+        return $basePrice > 0 ? [makeLineItem($roomLabel, $basePrice, 7, $nights, round($basePrice / $nights, 2))] : [];
     }
 
     $accommodationGross = 0.0;
@@ -461,9 +482,9 @@ function parseLineItems(array $booking, array $webhookItems = []): array {
         $label = $accommodationCount > 1
             ? $roomLabel . " ({$accommodationCount} Posten summiert – bitte Betrag in Beds24 prüfen!)"
             : $roomLabel;
-        $items[] = makeLineItem($label, $accommodationGross, 7);
+        $items[] = makeLineItem($label, $accommodationGross, 7, $nights, round($accommodationGross / $nights, 2));
     } elseif (empty($breakfastItems) && empty($extraItems) && $basePrice > 0) {
-        $items[] = makeLineItem($roomLabel, $basePrice, 7);
+        $items[] = makeLineItem($roomLabel, $basePrice, 7, $nights, round($basePrice / $nights, 2));
     }
 
     return array_merge($items, $breakfastItems, $extraItems);
@@ -623,6 +644,20 @@ function computeDueDate(\DateTime $invoiceDate, int $days): \DateTime {
         $due->modify('+1 day');
     }
     return $due;
+}
+
+/**
+ * Firmenrechnung payment-term text — "3 Werktage, sonst nächster Werktag"
+ * (Simone's rule, see computeDueDate()), computed from today's date. Used
+ * both at draft creation (when a company rate auto-detects Firmenrechnung)
+ * and whenever the review-page draft is re-saved with the checkbox on, so
+ * the shown term never drifts back to the generic 7-day text. The real,
+ * authoritative computation (from the actual invoiceDate) still happens
+ * again at final approval.
+ */
+function firmenPaymentNote(): string {
+    $due = computeDueDate(new \DateTime(date('Y-m-d')), 3);
+    return 'Zahlbar bis zum ' . $due->format('d.m.Y') . '.';
 }
 
 function calcTotals(array $items): array {

--- a/server/invoice-mailer.php
+++ b/server/invoice-mailer.php
@@ -5,7 +5,9 @@
  * Public API:
  *   sendMail(string $to, string $toName, string $subject, string $html, string $text, array $attachments): bool
  *   notifySimone(array $draft, bool $isRefresh = false): bool — sends review-link email to ADMIN_EMAIL
- *   sendInvoiceToGuest(array $draft, string $pdfBytes): bool
+ *   buildGuestInvoiceEmailParts(array $draft, bool $isPaid): array — subject+intro only, for the editable preview form
+ *   buildGuestInvoiceEmailHtml(array $draft, bool $isPaid, ?string $subjectOverride, ?string $introOverride): array — full subject+html, for preview or send
+ *   sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid, ?string $subjectOverride, ?string $introOverride): bool
  */
 
 require_once __DIR__ . '/config.php';
@@ -131,10 +133,78 @@ function notifySimone(array $draft, bool $isRefresh = false): bool {
 }
 
 // ---------------------------------------------------------------------------
+// Guest email — subject/intro (previewable/editable) vs. full send
+// ---------------------------------------------------------------------------
+
+/**
+ * The scenario-dependent subject and opening paragraph of the guest invoice
+ * email — the only two pieces Simone can edit on the review page before
+ * sending (see [[invoicing-review-edits]]). Everything else (payment block,
+ * bank details, cancellation warning, sign-off) is fixed and built in
+ * sendInvoiceToGuest() itself, so those legally/financially relevant parts
+ * can't be accidentally edited away.
+ *
+ * Returns ['subject' => string, 'intro' => string] — 'intro' is inner HTML
+ * (inline tags like <strong> allowed), not wrapped in a <p> yet.
+ */
+function buildGuestInvoiceEmailParts(array $draft, bool $isPaid = false): array {
+    $stay     = $draft['stay'];
+    $invNum   = $draft['invoiceNumber'] ?? '';
+    $scenario = $draft['scenario'] ?? 'B';
+
+    $esc      = fn(string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+    $checkIn  = ($stay['checkIn']  ?? '') ? date('d.m.Y', strtotime($stay['checkIn']))  : '–';
+    $checkOut = ($stay['checkOut'] ?? '') ? date('d.m.Y', strtotime($stay['checkOut'])) : '–';
+
+    if ($scenario === 'A') {
+        return [
+            'subject' => 'Ihre Rechnung zu Ihrer Buchung – Pension Volgenandt',
+            'intro'   => 'vielen Dank für Ihre Buchung — Ihre Buchungsbestätigung haben Sie bereits separat erhalten. '
+                . 'Anbei erhalten Sie nun Ihre Rechnung Nr. <strong>' . $esc($invNum) . '</strong> für Ihren Aufenthalt '
+                . 'vom ' . $checkIn . ' bis ' . $checkOut . '.',
+        ];
+    }
+
+    if ($scenario === 'C') {
+        $relatesTo = $draft['relatesTo'] ?? [];
+        $relatesToText = !empty($relatesTo)
+            ? ' Sie ergänzt Ihre bereits erhaltene Rechnung Nr. ' . $esc(implode(', ', $relatesTo)) . '.'
+            : '';
+        return [
+            'subject' => 'Ihre Rechnung für zusätzliche Leistungen – Pension Volgenandt',
+            'intro'   => 'anbei erhalten Sie Ihre Rechnung Nr. <strong>' . $esc($invNum) . '</strong> für zusätzliche Leistungen '
+                . 'während Ihres Aufenthalts vom ' . $checkIn . ' bis ' . $checkOut . '.' . $relatesToText,
+        ];
+    }
+
+    return [
+        'subject' => 'Ihre aktualisierte Rechnung – Pension Volgenandt',
+        'intro'   => 'anbei erhalten Sie Ihre aktualisierte Rechnung Nr. <strong>' . $esc($invNum) . '</strong> für Ihren Aufenthalt '
+            . 'vom ' . $checkIn . ' bis ' . $checkOut . '.',
+    ];
+}
+
+// ---------------------------------------------------------------------------
 // Send approved invoice PDF to the guest
 // ---------------------------------------------------------------------------
 
-function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false): bool {
+/**
+ * Builds the complete guest invoice email (subject + full HTML body) without
+ * sending it — used both by sendInvoiceToGuest() and by the "ready" review
+ * screen to show Simone exactly what will go out before she clicks send.
+ *
+ * $subjectOverride/$introOverride come from that review screen, where Simone
+ * can tweak the subject/opening paragraph — see buildGuestInvoiceEmailParts()
+ * for the defaults they start from. Overrides are treated as plain text
+ * (escaped, newlines→<br>), not HTML, since they're typed into a plain
+ * textarea.
+ */
+function buildGuestInvoiceEmailHtml(
+    array $draft,
+    bool $isPaid = false,
+    ?string $subjectOverride = null,
+    ?string $introOverride = null
+): array {
     $guest    = $draft['guest'];
     $stay     = $draft['stay'];
     $issuer   = $draft['issuer'];
@@ -142,9 +212,7 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
     $invNum   = $draft['invoiceNumber'] ?? '';
     $scenario = $draft['scenario'] ?? 'B';
 
-    $email = $guest['email'] ?? '';
-    $name  = $guest['name']  ?? '';
-    if (!$email) return false;
+    $name = $guest['name'] ?? '';
 
     $isFirmenrechnung = !empty($draft['isFirmenrechnung']);
 
@@ -155,6 +223,13 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
     $nights    = (int)($stay['nights']   ?? 0);
     $roomName  = $esc($stay['roomName'] ?? 'Zimmer');
     $total     = number_format((float)($totals['total'] ?? 0), 2, ',', '.') . '&nbsp;&euro;';
+
+    $parts    = buildGuestInvoiceEmailParts($draft, $isPaid);
+    $subject  = ($subjectOverride !== null && trim($subjectOverride) !== '') ? $subjectOverride : $parts['subject'];
+    $introHtml = ($introOverride !== null && trim($introOverride) !== '')
+        ? nl2br($esc($introOverride))
+        : $parts['intro'];
+    $introBlock = '<p style="line-height:1.7;margin:0 0 20px;">' . $introHtml . '</p>';
 
     // Payment section: either "please pay" (bank/PayPal/cancellation warning)
     // or, for bookings already paid in full via PayPal, a receipt confirmation.
@@ -174,7 +249,7 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
             $bic      = !empty($issuer['bic'])      ? 'BIC: ' . $esc($issuer['bic']) . '<br>' : '';
             $bankHtml = '
 <p style="background:#f0f7ee;padding:12px 16px;border-radius:6px;font-size:13px;line-height:1.9;margin:0 0 16px;">
-  ' . $bn . 'IBAN: ' . $esc($issuer['iban']) . '<br>' . $bic . '
+  Kontoinhaber: Ralf Volgenandt<br>' . $bn . 'IBAN: ' . $esc($issuer['iban']) . '<br>' . $bic . '
   Verwendungszweck: Rechnung ' . $esc($invNum) . ' &ndash; ' . $guestName . '
 </p>';
         }
@@ -213,15 +288,10 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
         // this email's only job is to deliver the reviewed, compliant invoice
         // that follows once Simone has checked it. Don't restate the booking
         // confirmation, just introduce the attached Rechnung.
-        $subject = 'Ihre Rechnung zu Ihrer Buchung – Pension Volgenandt';
         $html = '
 <div style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:560px;">
   <p style="margin:0 0 12px;">Sehr geehrte/r ' . $guestName . ',</p>
-  <p style="line-height:1.7;margin:0 0 20px;">
-    vielen Dank für Ihre Buchung — Ihre Buchungsbestätigung haben Sie bereits separat erhalten.
-    Anbei erhalten Sie nun Ihre Rechnung Nr. <strong>' . $esc($invNum) . '</strong> für Ihren Aufenthalt
-    vom ' . $checkIn . ' bis ' . $checkOut . '.
-  </p>
+  ' . $introBlock . '
 
   <table style="width:100%;border-collapse:collapse;margin:0 0 20px;background:#f9f7f3;border-radius:6px;">
     <tr>
@@ -252,18 +322,10 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
   ' . $signOff . '
 </div>';
     } elseif ($scenario === 'C') {
-        $relatesTo = $draft['relatesTo'] ?? [];
-        $relatesToText = !empty($relatesTo)
-            ? ' Sie ergänzt Ihre bereits erhaltene Rechnung Nr. ' . $esc(implode(', ', $relatesTo)) . '.'
-            : '';
-        $subject = 'Ihre Rechnung für zusätzliche Leistungen – Pension Volgenandt';
         $html = '
 <div style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:560px;">
   <p style="margin:0 0 12px;">Sehr geehrte/r ' . $guestName . ',</p>
-  <p style="line-height:1.7;margin:0 0 20px;">
-    anbei erhalten Sie Ihre Rechnung Nr. <strong>' . $esc($invNum) . '</strong> für zusätzliche Leistungen
-    während Ihres Aufenthalts vom ' . $checkIn . ' bis ' . $checkOut . '.' . $relatesToText . '
-  </p>
+  ' . $introBlock . '
   <table style="width:100%;border-collapse:collapse;margin:0 0 20px;background:#f9f7f3;border-radius:6px;">
     <tr><td style="padding:10px 14px;color:#666;width:38%;">Zimmer</td><td style="padding:10px 14px;">' . $roomName . '</td></tr>
     <tr style="border-top:1px solid #ede9e1;background:#f0f7ee;"><td style="padding:10px 14px;color:#666;">Gesamtbetrag</td><td style="padding:10px 14px;font-weight:700;color:#3d5a3e;">' . $total . '</td></tr>
@@ -274,13 +336,10 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
   ' . $paidNote . $bankHtml . $ppBtn . $cancelNote . $signOff . '
 </div>';
     } else {
-        $subject = 'Ihre aktualisierte Rechnung – Pension Volgenandt';
         $html = '
 <div style="font-family:Arial,sans-serif;font-size:14px;color:#333;max-width:560px;">
   <p style="margin:0 0 12px;">Sehr geehrte/r ' . $guestName . ',</p>
-  <p style="line-height:1.7;margin:0 0 20px;">anbei erhalten Sie Ihre aktualisierte Rechnung Nr.
-     <strong>' . $esc($invNum) . '</strong> für Ihren Aufenthalt
-     vom ' . $checkIn . ' bis ' . $checkOut . '.</p>
+  ' . $introBlock . '
   <table style="width:100%;border-collapse:collapse;margin:0 0 20px;background:#f9f7f3;border-radius:6px;">
     <tr><td style="padding:10px 14px;color:#666;width:38%;">Zimmer</td><td style="padding:10px 14px;">' . $roomName . '</td></tr>
     <tr style="border-top:1px solid #ede9e1;"><td style="padding:10px 14px;color:#666;">Zeitraum</td><td style="padding:10px 14px;">' . $checkIn . ' – ' . $checkOut . '</td></tr>
@@ -293,12 +352,35 @@ function sendInvoiceToGuest(array $draft, string $pdfBytes, bool $isPaid = false
 </div>';
     }
 
+    return ['subject' => $subject, 'html' => $html];
+}
+
+/**
+ * Sends the invoice PDF + email built by buildGuestInvoiceEmailHtml() to the
+ * guest, BCC'ing the office/Steuerbüro. Returns false without sending if the
+ * guest has no email on file.
+ */
+function sendInvoiceToGuest(
+    array $draft,
+    string $pdfBytes,
+    bool $isPaid = false,
+    ?string $subjectOverride = null,
+    ?string $introOverride = null
+): bool {
+    $guest = $draft['guest'];
+    $email = $guest['email'] ?? '';
+    $name  = $guest['name']  ?? '';
+    if (!$email) return false;
+
+    $invNum = $draft['invoiceNumber'] ?? '';
+    $built  = buildGuestInvoiceEmailHtml($draft, $isPaid, $subjectOverride, $introOverride);
+
     $bcc = [ADMIN_EMAIL];
     if (defined('STEUERBUERO_EMAIL') && STEUERBUERO_EMAIL !== '') {
         $bcc[] = STEUERBUERO_EMAIL;
     }
 
-    return sendMail($email, $name, $subject, $html, '', [
+    return sendMail($email, $name, $built['subject'], $built['html'], '', [
         ['data' => $pdfBytes, 'filename' => 'Rechnung-' . $invNum . '.pdf', 'mime' => 'application/pdf'],
     ], [], $bcc);
 }

--- a/server/invoice-pdf.php
+++ b/server/invoice-pdf.php
@@ -97,9 +97,15 @@ function buildInvoiceHtml(array $draft): string {
     if ($isFirmenrechnung && !empty($draft['companyName'])) {
         $companyLine = h($draft['companyName']) . '<br>';
     }
+    // Beds24 booking ID — always present on the draft, shown on every invoice
+    // so the guest/company reference matches what's in Beds24. Kept separate
+    // from the manually-entered Firmenrechnung reference below (a company's
+    // own internal order number, when they provide one).
+    $bookingIdLine = '<p style="margin:8px 0 0;font-size:11px;color:#666;">Buchungsnummer: ' . h((string)($draft['bookingId'] ?? '')) . '</p>';
+
     $bookingRefLine = '';
     if ($isFirmenrechnung && !empty($draft['bookingReference'])) {
-        $bookingRefLine = '<p style="margin:8px 0 0;font-size:11px;color:#666;">Buchungsnummer: ' . h($draft['bookingReference']) . '</p>';
+        $bookingRefLine = '<p style="margin:2px 0 0;font-size:11px;color:#666;">Referenz Firma: ' . h($draft['bookingReference']) . '</p>';
     }
 
     $checkIn  = formatDate($stay['checkIn']  ?? '');
@@ -170,7 +176,8 @@ function buildInvoiceHtml(array $draft): string {
     if (!empty($issuer['iban'])) {
         $bnName    = !empty($issuer['bankName']) ? h($issuer['bankName']) . '<br>' : '';
         $bicStr    = !empty($issuer['bic'])      ? 'BIC:&nbsp;' . h($issuer['bic']) . '<br>' : '';
-        $bankLines = $bnName
+        $bankLines = 'Kontoinhaber:&nbsp;Ralf Volgenandt<br>'
+            . $bnName
             . 'IBAN:&nbsp;' . h($issuer['iban']) . '<br>'
             . $bicStr
             . 'Verwendungszweck:&nbsp;Rechnung&nbsp;' . $invNum . '&nbsp;&ndash;&nbsp;' . $guestName;
@@ -220,6 +227,7 @@ function buildInvoiceHtml(array $draft): string {
           ' . ($addrStreet ? $addrStreet . '<br>' : '') . '
           ' . ($addrZipCity ?: '<span style="color:#aaa;">(Adresse nicht angegeben)</span>') . '
         </p>
+        ' . $bookingIdLine . '
         ' . $bookingRefLine . '
       </td>
       <td style="vertical-align:top;text-align:right;">
@@ -261,6 +269,8 @@ function buildInvoiceHtml(array $draft): string {
     </tr>
   </table>
 
+  ' . $ohneFruehstueckBlock . '
+
   <!-- Payment info -->
   <div style="margin-top:28px;padding:14px 0;font-size:12px;line-height:1.8;">
     <p style="margin:0 0 8px;font-size:13px;"><strong>Zahlungsbedingungen:</strong> ' . h($draft['paymentNote'] ?? '') . '</p>
@@ -282,7 +292,6 @@ function buildInvoiceHtml(array $draft): string {
     ' . $paypalBlock . '
   </div>
 
-  ' . $ohneFruehstueckBlock . '
   ' . $noteBlock . '
 
   <!-- Page footer -->

--- a/server/invoice-review.php
+++ b/server/invoice-review.php
@@ -3,9 +3,12 @@
  * Invoice draft review page.
  * Simone visits this page via the link in her notification email.
  *
- * GET  ?token=UUID          — show draft + approve/reject form
- * GET  ?token=UUID&dl=1     — download approved PDF
- * POST action=approve       — finalize: generate PDF, email guest, mark approved
+ * GET  ?token=UUID          — show draft (editable while pending, review-before-send while ready)
+ * GET  ?token=UUID&dl=1     — download the generated PDF (status ready or approved)
+ * POST action=save          — persist edits, stay pending (no number/PDF/email yet)
+ * POST action=approve       — assign invoice number, generate PDF, status → ready (NOT sent yet)
+ * POST action=send          — send the (possibly re-worded) email + PDF to the guest, status → approved
+ * POST action=back          — ready → pending again; the assigned invoice number stays reserved
  * POST action=reject        — mark rejected
  */
 
@@ -13,6 +16,61 @@ require_once __DIR__ . '/config.php';
 require_once __DIR__ . '/invoice-draft.php';
 require_once __DIR__ . '/invoice-pdf.php';
 require_once __DIR__ . '/invoice-mailer.php';
+
+// ---------------------------------------------------------------------------
+// Shared: apply the editable form fields onto a draft (used by save+approve)
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies every editable field from the pending review form onto $draft:
+ * guest data, line items (+recomputed totals), Firmenrechnung fields (incl.
+ * the always-current 3-Werktage paymentNote), the free-text note, and the
+ * "already paid" flag. Never touches invoiceNumber/invoiceDate/status — those
+ * are only set by the approve/send/back handlers below.
+ */
+function applyDraftEdits(array &$draft, array $post): void {
+    $draft['guest']['name']    = trim($post['guest_name']    ?? '') ?: ($draft['guest']['name'] ?? 'Unbekannt');
+    $draft['guest']['email']   = trim($post['guest_email']   ?? ($draft['guest']['email']   ?? ''));
+    $draft['guest']['address'] = trim($post['guest_address'] ?? ($draft['guest']['address'] ?? ''));
+    $draft['guest']['zip']     = trim($post['guest_zip']     ?? ($draft['guest']['zip']     ?? ''));
+    $draft['guest']['city']    = trim($post['guest_city']    ?? ($draft['guest']['city']    ?? ''));
+
+    // Line-item edits — blank description rows (the spare ones) are dropped
+    $editedItems = [];
+    foreach (($post['item_desc'] ?? []) as $i => $desc) {
+        $desc = trim((string)$desc);
+        if ($desc === '') continue;
+        $qty   = (float)($post['item_qty'][$i]  ?? 1);
+        $unit  = (float)str_replace(',', '.', (string)($post['item_unit'][$i] ?? 0));
+        $vat   = (int)($post['item_vat'][$i] ?? 7);
+        $gross = round($qty * $unit, 2);
+        if (abs($gross) < 0.01) continue;
+        $editedItems[] = makeLineItem($desc, $gross, $vat, $qty, $unit);
+    }
+    if (!empty($editedItems)) {
+        $draft['lineItems'] = $editedItems;
+        $draft['totals']    = calcTotals($editedItems);
+    }
+
+    $isFirmenrechnung = ($post['is_firmenrechnung'] ?? '') === '1';
+    $draft['isFirmenrechnung'] = $isFirmenrechnung;
+    $draft['companyName']      = trim($post['company_name']      ?? '');
+    $draft['bookingReference'] = trim($post['booking_reference'] ?? '');
+    $draft['ohneFruehstueck']  = $isFirmenrechnung && ($post['ohne_fruehstueck'] ?? '') === '1';
+
+    // Firmenrechnung: 3 Werktage statt der üblichen 7 Tage (Simones Regel,
+    // 2026-08-03) — always recomputed from today's date rather than trusting
+    // free text, both here (live preview while still editing) and at the
+    // actual approval (invoiceDate is always today too, so the two never
+    // disagree). Keeps the field from drifting back to the generic 7-Tage
+    // text after the checkbox is toggled.
+    $draft['paymentNote'] = $isFirmenrechnung
+        ? firmenPaymentNote()
+        : (trim($post['payment_note'] ?? '') ?: ($draft['paymentNote'] ?? ''));
+
+    $draft['note'] = trim($post['note'] ?? '');
+    $draft['manuallyMarkedPaid'] = ($post['already_paid'] ?? '') === '1';
+}
 
 // ---------------------------------------------------------------------------
 // Load and validate draft
@@ -32,10 +90,10 @@ $invNum = $draft['invoiceNumber'] ?? '';
 $pdfPath = __DIR__ . '/invoices/sent/' . $token . '.pdf';
 
 // ---------------------------------------------------------------------------
-// PDF download
+// PDF download — available once the PDF has been generated (ready or sent)
 // ---------------------------------------------------------------------------
 
-if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['dl']) && $status === 'approved' && file_exists($pdfPath)) {
+if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['dl']) && in_array($status, ['ready', 'approved'], true) && file_exists($pdfPath)) {
     header('Content-Type: application/pdf');
     header('Content-Disposition: attachment; filename="Rechnung-' . $invNum . '.pdf"');
     header('Content-Length: ' . filesize($pdfPath));
@@ -44,94 +102,86 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET' && isset($_GET['dl']) && $status === 'a
 }
 
 // ---------------------------------------------------------------------------
-// POST: approve or reject
+// POST: save / approve / send / back / reject
 // ---------------------------------------------------------------------------
 
 $flash = '';
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST' && $status === 'pending') {
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $action = $_POST['action'] ?? '';
-    $note   = trim($_POST['note'] ?? '');
 
-    if ($action === 'approve') {
+    if ($action === 'save' && $status === 'pending') {
+        applyDraftEdits($draft, $_POST);
+        file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        draftLog((int)($draft['bookingId'] ?? 0), 'saved', "token={$token}");
+        $flash = 'ok:Änderungen gespeichert.';
+
+    } elseif ($action === 'approve' && $status === 'pending') {
         $requestedNumber = trim($_POST['invoice_number'] ?? '') ?: peekNextInvoiceNumber();
 
         if (!tryAssignInvoiceNumber($draft, $requestedNumber, $draftPath)) {
             $flash = 'err:Rechnungsnummer ' . htmlspecialchars($requestedNumber) . ' ist ungültig oder wird bereits verwendet. Bitte eine andere Nummer wählen.';
         } else {
-            // Apply guest-data edits
-            $draft['guest']['name']    = trim($_POST['guest_name']    ?? '') ?: ($draft['guest']['name'] ?? 'Unbekannt');
-            $draft['guest']['email']   = trim($_POST['guest_email']   ?? ($draft['guest']['email']   ?? ''));
-            $draft['guest']['address'] = trim($_POST['guest_address'] ?? ($draft['guest']['address'] ?? ''));
-            $draft['guest']['zip']     = trim($_POST['guest_zip']     ?? ($draft['guest']['zip']     ?? ''));
-            $draft['guest']['city']    = trim($_POST['guest_city']    ?? ($draft['guest']['city']    ?? ''));
-
-            // Apply line-item edits — blank description rows (the spare ones) are dropped
-            $editedItems = [];
-            foreach (($_POST['item_desc'] ?? []) as $i => $desc) {
-                $desc = trim((string)$desc);
-                if ($desc === '') continue;
-                $qty   = (float)($_POST['item_qty'][$i]  ?? 1);
-                $unit  = (float)str_replace(',', '.', (string)($_POST['item_unit'][$i] ?? 0));
-                $vat   = (int)($_POST['item_vat'][$i] ?? 7);
-                $gross = round($qty * $unit, 2);
-                if (abs($gross) < 0.01) continue;
-                $editedItems[] = makeLineItem($desc, $gross, $vat, $qty, $unit);
-            }
-            if (!empty($editedItems)) {
-                $draft['lineItems'] = $editedItems;
-                $draft['totals']    = calcTotals($editedItems);
-            }
-
-            $isFirmenrechnung = ($_POST['is_firmenrechnung'] ?? '') === '1';
-            $draft['isFirmenrechnung'] = $isFirmenrechnung;
-            $draft['companyName']      = trim($_POST['company_name']      ?? '');
-            $draft['bookingReference'] = trim($_POST['booking_reference'] ?? '');
-            $draft['ohneFruehstueck']  = $isFirmenrechnung && ($_POST['ohne_fruehstueck'] ?? '') === '1';
+            applyDraftEdits($draft, $_POST);
 
             $draft['invoiceDate'] = date('Y-m-d');
             $draft['approvedAt']  = date('c');
-            $draft['status']      = 'approved';
+            $draft['status']      = 'ready';
 
-            // Firmenrechnung: 3 Werktage statt der üblichen 7 Tage (Simones
-            // Regel, 2026-08-03) — always computed from the actual due date
-            // rather than trusting free text, so it can't drift out of sync
-            // with the "Wichtiger Hinweis" storno wording below.
-            if ($isFirmenrechnung) {
-                $due = computeDueDate(new \DateTime($draft['invoiceDate']), 3);
-                $draft['paymentNote'] = 'Zahlbar bis zum ' . $due->format('d.m.Y') . '.';
-            } else {
-                $draft['paymentNote'] = trim($_POST['payment_note'] ?? '') ?: ($draft['paymentNote'] ?? '');
-            }
-            $draft['note']        = $note;
+            $isPaid = !empty($draft['manuallyMarkedPaid']);
 
-            $isPaid = ($_POST['already_paid'] ?? '') === '1';
-            $draft['manuallyMarkedPaid'] = $isPaid;
-
-            // Generate PDF
+            // Generate + save the real PDF now, so the "ready" screen can
+            // offer an exact download, not just the HTML approximation.
             $pdfBytes = generateInvoicePdf($draft);
-
-            // Save PDF file
             $sentDir = __DIR__ . '/invoices/sent';
             if (!is_dir($sentDir)) mkdir($sentDir, 0750, true);
             file_put_contents($pdfPath, $pdfBytes);
 
-            // Email guest (Steuerbüro receives a BCC copy automatically)
-            $emailSent = sendInvoiceToGuest($draft, $pdfBytes, $isPaid);
-            $draft['guestEmailSent'] = $emailSent;
+            // Prefill the editable email subject/intro with sensible
+            // defaults — Simone can adjust before the actual send.
+            $emailParts = buildGuestInvoiceEmailParts($draft, $isPaid);
+            $draft['emailSubject'] = $emailParts['subject'];
+            $draft['emailIntro']   = trim(preg_replace('/\s+/u', ' ', strip_tags($emailParts['intro'])));
 
-            // Persist
             file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
-            draftLog((int)($draft['bookingId'] ?? 0), 'approved', "token={$token} invoiceNumber={$draft['invoiceNumber']} emailSent=" . ($emailSent ? '1' : '0') . ' paid=' . ($isPaid ? '1' : '0'));
+            draftLog((int)($draft['bookingId'] ?? 0), 'ready', "token={$token} invoiceNumber={$draft['invoiceNumber']}");
 
-            $status = 'approved';
-            $flash  = $emailSent
-                ? 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' genehmigt und an ' . htmlspecialchars($draft['guest']['email'] ?? '') . ' gesendet.'
-                : 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' genehmigt. Kein E-Mail-Versand — Gast hat keine E-Mail-Adresse hinterlegt.';
+            $status = 'ready';
+            $flash  = 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' erzeugt — bitte PDF und E-Mail-Text unten prüfen, bevor sie an den Gast geht.';
         }
 
-    } elseif ($action === 'reject') {
-        $draft['note']       = $note;
+    } elseif ($action === 'send' && $status === 'ready') {
+        $subjectOverride = trim($_POST['email_subject'] ?? '');
+        $introOverride   = trim($_POST['email_intro']   ?? '');
+        $isPaid = !empty($draft['manuallyMarkedPaid']);
+
+        $pdfBytes = file_exists($pdfPath) ? file_get_contents($pdfPath) : generateInvoicePdf($draft);
+
+        $emailSent = sendInvoiceToGuest($draft, $pdfBytes, $isPaid, $subjectOverride, $introOverride);
+        $draft['guestEmailSent'] = $emailSent;
+        if ($subjectOverride !== '') $draft['emailSubject'] = $subjectOverride;
+        if ($introOverride   !== '') $draft['emailIntro']   = $introOverride;
+        $draft['status'] = 'approved';
+        $draft['sentAt'] = date('c');
+
+        file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        draftLog((int)($draft['bookingId'] ?? 0), 'approved', "token={$token} invoiceNumber={$draft['invoiceNumber']} emailSent=" . ($emailSent ? '1' : '0') . ' paid=' . ($isPaid ? '1' : '0'));
+
+        $status = 'approved';
+        $flash  = $emailSent
+            ? 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' gesendet an ' . htmlspecialchars($draft['guest']['email'] ?? '') . '.'
+            : 'ok:Rechnung ' . htmlspecialchars($draft['invoiceNumber']) . ' genehmigt. Kein E-Mail-Versand — Gast hat keine E-Mail-Adresse hinterlegt.';
+
+    } elseif ($action === 'back' && $status === 'ready') {
+        $draft['status'] = 'pending';
+        file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        draftLog((int)($draft['bookingId'] ?? 0), 'back_to_pending', "token={$token} invoiceNumber=" . ($draft['invoiceNumber'] ?? ''));
+
+        $status = 'pending';
+        $flash  = 'ok:Zurück zur Bearbeitung. Rechnungsnummer ' . htmlspecialchars($draft['invoiceNumber'] ?? '') . ' bleibt reserviert.';
+
+    } elseif ($action === 'reject' && $status === 'pending') {
+        $draft['note']       = trim($_POST['note'] ?? '');
         $draft['status']     = 'rejected';
         $draft['rejectedAt'] = date('c');
         file_put_contents($draftPath, json_encode($draft, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
@@ -157,10 +207,17 @@ $total    = number_format((float)($totals['total'] ?? 0), 2, ',', '.');
 // may still be unset (pending), in which case show a live suggestion.
 $invNum = $draft['invoiceNumber'] ?? ($status === 'pending' ? peekNextInvoiceNumber() : '');
 
-$statusLabels = ['pending' => 'Ausstehend', 'approved' => 'Genehmigt', 'rejected' => 'Abgelehnt'];
-$statusColors = ['pending' => '#e67e22',    'approved' => '#27ae60',   'rejected' => '#c0392b'];
+$statusLabels = ['pending' => 'Ausstehend', 'ready' => 'Bereit zum Versand', 'approved' => 'Gesendet', 'rejected' => 'Abgelehnt'];
+$statusColors = ['pending' => '#e67e22',    'ready' => '#2980b9',           'approved' => '#27ae60',  'rejected' => '#c0392b'];
 $statusLabel  = $statusLabels[$status] ?? $status;
 $statusColor  = $statusColors[$status] ?? '#888';
+
+// "Bereits bezahlt" checkbox default: once Save/Genehmigen has run at least
+// once, manuallyMarkedPaid reflects Simone's own choice — otherwise fall
+// back to the Beds24-detected prePaid default.
+$alreadyPaidChecked = array_key_exists('manuallyMarkedPaid', $draft)
+    ? !empty($draft['manuallyMarkedPaid'])
+    : !empty($draft['prePaid']);
 
 // Preview needs a non-empty invoice number even before approval — use the
 // same live suggestion shown in the form, without persisting it to the draft.
@@ -195,6 +252,8 @@ table.info td:first-child { color: #777; width: 150px; white-space: nowrap; }
 .btn { padding: 11px 22px; border: none; border-radius: 6px; font-size: 14px; font-weight: 600; cursor: pointer; }
 .btn-green { background: #3d5a3e; color: #fff; }
 .btn-green:hover { background: #2e4530; }
+.btn-blue  { background: #2980b9; color: #fff; }
+.btn-blue:hover  { background: #216a99; }
 .btn-red   { background: #c0392b; color: #fff; }
 .btn-red:hover   { background: #a93226; }
 .btn-link  { background: none; border: 1px solid #ccc; color: #555; }
@@ -217,6 +276,8 @@ table.items-edit td { padding: 4px 6px; }
 .checkbox-row input { width: auto; margin-top: 3px; }
 .flash-ok  { background: #eafaf1; border: 1px solid #a9dfbf; color: #1e8449; border-radius: 6px; padding: 13px 16px; margin-bottom: 18px; }
 .flash-err { background: #fdecea; border: 1px solid #f5b7b1; color: #c0392b; border-radius: 6px; padding: 13px 16px; margin-bottom: 18px; }
+.warn-note { background: #fff3cd; border-left: 3px solid #e6a817; border-radius: 4px; padding: 8px 12px; font-size: 12px; color: #7a5c00; margin: -2px 0 14px; display: none; }
+.hint { font-size: 12px; color: #999; margin: -2px 0 14px; }
 .preview iframe { width: 100%; height: 680px; border: none; display: block; border-radius: 0 0 8px 8px; }
 .preview-head { background: #f8f8f8; border-bottom: 1px solid #e0e0e0; padding: 10px 16px; font-size: 12px; color: #888; border-radius: 8px 8px 0 0; }
 label { display: block; font-weight: 600; margin-bottom: 6px; }
@@ -228,7 +289,7 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
   <?php if ($flashMsg): ?>
   <div class="flash-<?= $flashType === 'ok' ? 'ok' : 'err' ?>">
     <?= $flashType === 'ok' ? '✓' : '✗' ?> <?= htmlspecialchars($flashMsg) ?>
-    <?php if ($status === 'approved' && file_exists($pdfPath)): ?>
+    <?php if (in_array($status, ['ready', 'approved'], true) && file_exists($pdfPath)): ?>
     &nbsp;·&nbsp; <a href="?token=<?= urlencode($token) ?>&dl=1" style="font-weight:700;">PDF herunterladen</a>
     <?php endif; ?>
   </div>
@@ -254,7 +315,7 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
       <?php if (!empty($draft['isFirmenrechnung'])): ?>
       <tr><td>Firma</td><td><strong><?= htmlspecialchars($draft['companyName'] ?? '–') ?></strong></td></tr>
       <?php if (!empty($draft['bookingReference'])): ?>
-      <tr><td>Buchungsnummer</td><td><?= htmlspecialchars($draft['bookingReference']) ?></td></tr>
+      <tr><td>Referenz Firma</td><td><?= htmlspecialchars($draft['bookingReference']) ?></td></tr>
       <?php endif; ?>
       <?php endif; ?>
       <tr><td>Zimmer</td><td><?= htmlspecialchars($stay['roomName'] ?? '–') ?></td></tr>
@@ -264,7 +325,10 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
       <tr><td>Zahlungsstatus</td><td><span style="color:#27ae60;font-weight:600;">Bereits vollständig bezahlt</span> (laut Beds24 bei Buchungseingang)</td></tr>
       <?php endif; ?>
       <?php if (!empty($draft['approvedAt'])): ?>
-      <tr><td>Genehmigt</td><td><?= date('d.m.Y H:i', strtotime($draft['approvedAt'])) ?></td></tr>
+      <tr><td>Erzeugt</td><td><?= date('d.m.Y H:i', strtotime($draft['approvedAt'])) ?></td></tr>
+      <?php endif; ?>
+      <?php if (!empty($draft['sentAt'])): ?>
+      <tr><td>Gesendet</td><td><?= date('d.m.Y H:i', strtotime($draft['sentAt'])) ?></td></tr>
       <?php endif; ?>
       <?php if (!empty($draft['note'])): ?>
       <tr><td>Notiz</td><td><?= htmlspecialchars($draft['note']) ?></td></tr>
@@ -292,14 +356,15 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
       <label class="checkbox-row">
         <input type="checkbox" id="is_firmenrechnung" name="is_firmenrechnung" value="1"
                <?= !empty($draft['isFirmenrechnung']) ? 'checked' : '' ?>
-               onchange="document.getElementById('firmen-fields').style.display = this.checked ? 'block' : 'none';">
+               onchange="document.getElementById('firmen-fields').style.display = this.checked ? 'block' : 'none'; checkNameCompanyMatch();">
         Firmenrechnung (z.&nbsp;B. Fero Fensterbau, Barczewski) — 3 Werktage Zahlungsziel statt 7 Tage
       </label>
       <div id="firmen-fields" style="display:<?= !empty($draft['isFirmenrechnung']) ? 'block' : 'none' ?>;margin-bottom:16px;">
         <div class="field-row">
-          <div><label for="company_name">Firma</label><input type="text" id="company_name" name="company_name" value="<?= htmlspecialchars($draft['companyName'] ?? '') ?>"></div>
-          <div><label for="booking_reference">Buchungsnummer <span style="font-weight:400;color:#999;">(optional)</span></label><input type="text" id="booking_reference" name="booking_reference" value="<?= htmlspecialchars($draft['bookingReference'] ?? '') ?>"></div>
+          <div><label for="company_name">Firma</label><input type="text" id="company_name" name="company_name" value="<?= htmlspecialchars($draft['companyName'] ?? '') ?>" oninput="checkNameCompanyMatch();"></div>
+          <div><label for="booking_reference">Referenz Firma <span style="font-weight:400;color:#999;">(optional, interne Nummer der Firma)</span></label><input type="text" id="booking_reference" name="booking_reference" value="<?= htmlspecialchars($draft['bookingReference'] ?? '') ?>"></div>
         </div>
+        <div id="name-company-warn" class="warn-note">Name und Firma sehen identisch aus — bitte prüfen, ob hier eine Ansprechperson statt der Firma stehen sollte (siehe Hinweis zur Rechnungsempfänger-Eingabe).</div>
         <label class="checkbox-row">
           <input type="checkbox" name="ohne_fruehstueck" value="1" <?= !empty($draft['ohneFruehstueck']) ? 'checked' : '' ?>>
           Preis ohne Frühstück — erscheint als Hinweis auf der Rechnung
@@ -344,20 +409,62 @@ label { display: block; font-weight: 600; margin-bottom: 6px; }
       <textarea id="note" name="note" rows="2" placeholder="z.B. Rabatt, Sondervereinbarung ..."><?= htmlspecialchars($draft['note'] ?? '') ?></textarea>
 
       <label class="checkbox-row">
-        <input type="checkbox" name="already_paid" value="1" <?= !empty($draft['prePaid']) ? 'checked' : '' ?>>
+        <input type="checkbox" name="already_paid" value="1" <?= $alreadyPaidChecked ? 'checked' : '' ?>>
         Bereits bezahlt (z.&nbsp;B. bar/Karte vor Ort) — Gast erhält eine Zahlungsbestätigung statt einer Zahlungsaufforderung
       </label>
 
       <div class="actions">
-        <button type="submit" name="action" value="approve" class="btn btn-green">✓ Genehmigen &amp; an Gast senden</button>
+        <button type="submit" name="action" value="save" class="btn btn-link">💾 Speichern</button>
+        <button type="submit" name="action" value="approve" class="btn btn-green">✓ Genehmigen (Rechnung erzeugen)</button>
         <button type="submit" name="action" value="reject"  class="btn btn-red"
                 onclick="return confirm('Entwurf wirklich ablehnen?');">✗ Ablehnen</button>
       </div>
     </form>
   </div>
+
+  <script>
+  function checkNameCompanyMatch() {
+    var isFirma = document.getElementById('is_firmenrechnung').checked;
+    var name    = (document.getElementById('guest_name').value || '').trim().toLowerCase();
+    var company = (document.getElementById('company_name').value || '').trim().toLowerCase();
+    var warn    = document.getElementById('name-company-warn');
+    warn.style.display = (isFirma && name !== '' && company !== '' && name === company) ? 'block' : 'none';
+  }
+  document.getElementById('guest_name').addEventListener('input', checkNameCompanyMatch);
+  checkNameCompanyMatch();
+  </script>
+
+  <?php elseif ($status === 'ready'): ?>
+  <div class="card">
+    <p style="margin:0 0 14px;font-size:13px;color:#555;line-height:1.6;">
+      Rechnung <strong><?= htmlspecialchars($invNum) ?></strong> wurde erzeugt, aber <strong>noch nicht an den Gast gesendet</strong>.
+      PDF unten prüfen und den Mailtext bei Bedarf anpassen, bevor sie rausgeht.
+    </p>
+    <a href="?token=<?= urlencode($token) ?>&dl=1" class="btn btn-link">⬇ PDF herunterladen</a>
+
+    <?php if (empty($guest['email'])): ?>
+    <div class="warn-note" style="display:block;margin-top:16px;">Gast hat keine E-Mail-Adresse hinterlegt — es kann nichts automatisch gesendet werden. Über "Zurück zur Bearbeitung" ergänzen.</div>
+    <?php endif; ?>
+
+    <h2 class="section-title">E-Mail an den Gast</h2>
+    <form method="post">
+      <label for="email_subject">Betreff</label>
+      <input type="text" id="email_subject" name="email_subject" value="<?= htmlspecialchars($draft['emailSubject'] ?? '') ?>">
+
+      <label for="email_intro">Einleitungstext</label>
+      <textarea id="email_intro" name="email_intro" rows="4"><?= htmlspecialchars($draft['emailIntro'] ?? '') ?></textarea>
+      <p class="hint">Zahlungshinweis, Bankdaten/QR-Code und Signatur werden automatisch angehängt und sind hier nicht editierbar (siehe Rechnungsvorschau unten für den genauen Inhalt).</p>
+
+      <div class="actions">
+        <button type="submit" name="action" value="send" class="btn btn-green">✓ Jetzt an Gast senden</button>
+        <button type="submit" name="action" value="back" class="btn btn-link"
+                onclick="return confirm('Zurück zur Bearbeitung? Die Rechnungsnummer <?= htmlspecialchars($invNum) ?> bleibt reserviert.');">← Zurück zur Bearbeitung</button>
+      </div>
+    </form>
+  </div>
   <?php elseif ($status === 'approved' && file_exists($pdfPath)): ?>
   <div class="card">
-    <a href="?token=<?= urlencode($token) ?>&dl=1" class="btn btn-link">⬇ Genehmigte Rechnung herunterladen</a>
+    <a href="?token=<?= urlencode($token) ?>&dl=1" class="btn btn-link">⬇ Gesendete Rechnung herunterladen</a>
   </div>
   <?php endif; ?>
 


### PR DESCRIPTION
## Summary
- Trennt "Genehmigen & senden" in Speichern -> Genehmigen (Nummer + PDF, Status "Bereit zum Versand") -> Jetzt an Gast senden (editierbarer Betreff/Einleitungstext), damit PDF und E-Mail vor dem Versand geprüft werden können.
- Fixt den Einzelpreis der Übernachtungsposition (zeigte bisher immer Anzahl=1/Gesamtpreis statt Nächte x Preis pro Nacht).
- Buchungsnummer (Beds24-ID) erscheint jetzt auf jeder Rechnung, nicht nur bei Firmenrechnungen.
- Zahlungshinweis "3 Werktage" bei Firmenrechnung wird jetzt sofort bei Erstellung/Speichern berechnet statt erst beim finalen Genehmigen.
- "Ohne Frühstück"-Hinweis steht jetzt direkt unter den Übernachtungskosten.
- Kontoinhaber "Ralf Volgenandt" in den Bankdaten ergänzt (PDF + Mail).
- Duplikat-Schutz erweitert: ein Webhook während "Bereit zum Versand" löst jetzt einen Nachtrag statt einer zweiten Vollrechnung aus.
- Kleiner Hinweis auf der Review-Seite, falls Name und Firma identisch eingegeben wurden.

## Test plan
- [ ] Kein lokaler PHP/Composer-Stack vorhanden — Code wurde sorgfältig durchgelesen statt lokal ausgeführt.
- [ ] Vor Live-Deploy: Test-Entwurf manuell als JSON in `server/invoices/drafts/` ablegen (kein echter Webhook) und den kompletten Ablauf Speichern -> Genehmigen -> Mail-Vorschau -> Senden über die echte Review-URL mit einer Test-E-Mail-Adresse durchklicken.
- [ ] Deploy wie gewohnt manuell per IONOS Webspace Explorer (kein CI für `server/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)